### PR TITLE
Enhance settings dialog, keypad layout, and platform support

### DIFF
--- a/.zcode/plans/plan-sess_bbd72b49-68e6-4b9f-bd90-cedce92575dd.md
+++ b/.zcode/plans/plan-sess_bbd72b49-68e6-4b9f-bd90-cedce92575dd.md
@@ -1,0 +1,70 @@
+## Overview
+Add a **settings button** next to the DEG/RAD chip in the AppBar. It opens a settings dialog with two things:
+1. A **theme switcher** (Light / Dark / System) — persisted to `SharedPreferences` so it's remembered across launches.
+2. The **app version** displayed as `x.y.z (build n)` (e.g. `1.0.0 (build 1)`), read at runtime from `package_info_plus`.
+
+The app already has `AppTheme.light`/`AppTheme.dark`, `shared_preferences` (via `SharedPreferencesAsync`), Riverpod, and `package_info_plus` (declared but unused) — so this is mostly wiring, using existing patterns (mirror `WindowStateStorage` for persistence, mirror `CalculatorViewModel` Notifier for state).
+
+## Files to create
+
+### 1. `lib/app/theme_settings.dart` — persistence + Riverpod state
+Mirrors the `WindowStateStorage` pattern (same `SharedPreferencesAsync` API, same Chinese-comment style already used in the file).
+
+- **`ThemePreference` enum**: `light`, `dark`, `system`, each with:
+  - a `label` getter ('Light' / 'Dark' / 'System') — mirrors `AngleMode.label` style in `angle_mode.dart`.
+  - a `ThemeMode` material getter mapping to `ThemeMode.light` / `ThemeMode.dark` / `ThemeMode.system`.
+- **`ThemeSettingsStorage`** (static class like `WindowStateStorage`):
+  - key `'theme_preference'` (stored as `String`).
+  - `Future<ThemePreference> load()` → returns saved value or `ThemePreference.system` default.
+  - `Future<void> save(ThemePreference)` → persists.
+- **`themeSettingsProvider`** — a `Notifier<ThemePreference>`:
+  - `build()` reads `ref` is not async-friendly for Notifier, so load lazily: initialize to `ThemePreference.system`, then on construction kick off an async load via an async notifier. **Use `AsyncNotifier`** to avoid blocking: `AsyncNotifierProvider<ThemeSettingsNotifier, ThemePreference>`.
+    - Actually simpler/cleaner with the existing codebase's sync `Notifier` pattern: bootstrap.dart (which already does async init) loads the saved preference *before* `runApp` and passes it as an override to `ProviderScope.overrides`. This guarantees the correct theme on the very first frame (no flash). The Notifier then just holds/updates it and saves on change.
+  - `void set(ThemePreference)` → `state = x; unawaited(ThemeSettingsStorage.save(x));`
+
+**Chosen approach (flash-free, matches existing bootstrap pattern):**
+- `ThemeSettingsNotifier extends Notifier<ThemePreference>` with `build()` returning the initial value.
+- A `Future<ThemePreference> Function()` is **not** needed because `bootstrap()` already runs async init before `runApp`. It will load the saved preference and override the provider's initial value via `ProviderScope(overrides: [...])`.
+
+### 2. `lib/features/calculator/view/widgets/settings_button.dart`
+A small `StatelessWidget` rendering an `IconButton(icon: Icons.settings, ...)` whose `onPressed` shows the settings dialog. Kept as its own widget to mirror the `mode_indicator.dart` separation.
+
+### 3. `lib/features/calculator/view/widgets/settings_dialog.dart`
+A `ConsumerWidget` (needs `ref` to read/write `themeSettingsProvider` and watch package info) returning an `AlertDialog`:
+- Title: "Settings".
+- **Theme section**: a `Column` of three `RadioListTile<ThemePreference>` (System / Light / Dark). Selecting one calls `ref.read(themeSettingsProvider.notifier).set(value)`.
+- **About section**: a `ListTile` showing version as `1.0.0 (build 1)`. Version comes from a new `packageInfoProvider` (a `FutureProvider<PackageInfo>` using `package_info_plus`) — displayed via `FutureBuilder` so it shows `'—'` until loaded.
+- A single Close action button.
+
+## Files to modify
+
+### 4. `lib/app/app.dart`
+- Make `ScientificCalculatorApp` a **`ConsumerWidget`** (currently `StatelessWidget`).
+- Replace the hardcoded `themeMode: ThemeMode.system` with `themeMode: ref.watch(themeSettingsProvider).themeMode`.
+
+### 5. `lib/app/bootstrap.dart`
+- After window setup, before `runApp`: load `final savedTheme = await ThemeSettingsStorage.load();`
+- Pass it as an override: `ProviderScope(overrides: [themeSettingsProvider.overrideWith(() => ThemeSettingsNotifier()..preload(savedTheme))], child: ...)`. Concretely the notifier takes the initial value; to keep it simple I'll give `ThemeSettingsNotifier` an injectable initial via a constructor arg consumed in `build()`, or use a top-level `late` init value. Cleanest: `Notifier.build()` reads the value, so I'll pass it through an override that constructs the notifier with the value. Final detail resolved at implementation time to satisfy Riverpod 3.x `overrideWith`.
+
+### 6. `lib/features/calculator/view/calculator_screen.dart`
+- Add a `SettingsButton` next to `ModeIndicator` inside the AppBar `actions` `Row`/`Padding` (the DEG/RAD chip stays; settings icon goes to its right).
+
+## Tests to add (match existing `test/` mirror structure)
+
+### 7. `test/app/theme_settings_test.dart`
+- `ThemePreference.label` values, `.themeMode` mapping.
+- `ThemeSettingsStorage.save`/`load` round-trip (use `SharedPreferences` test setup — `SharedPreferences.setMockInitialValues({})`). Verifies default = system when unset.
+
+### 8. `test/features/calculator/view/widgets/settings_dialog_test.dart`
+- Pump the dialog in a `ProviderScope` + `MaterialApp`, tap a radio, assert provider state changed and label rendered.
+- Assert version row renders once `PackageInfo` future resolves (mock via provider override).
+
+## Verification
+- `flutter analyze` — no new warnings.
+- `flutter test` — all existing + new tests pass.
+- Manual (optional): run app, toggle themes, restart, confirm persistence and the `1.0.0 (build 1)` string in the dialog.
+
+## Notes / non-goals
+- Angle mode is **not** persisted (out of scope; you only asked for theme).
+- No new dependencies added — everything (`shared_preferences`, `package_info_plus`, `flutter_riverpod`) is already in pubspec.
+- Existing "follow system" behavior is preserved as the **System** option and remains the default.

--- a/lib/app/always_on_top_settings.dart
+++ b/lib/app/always_on_top_settings.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// 視窗「永遠置頂」(always on top / pin) 偏好是否已開啟。
+///
+/// 沿用 [WindowStateStorage] 與 [ThemeSettingsStorage] 的
+/// `SharedPreferencesAsync` + Riverpod `Notifier` 模式。
+class AlwaysOnTopStorage {
+  static const _key = 'window_always_on_top';
+  static final SharedPreferencesAsync _preferences = SharedPreferencesAsync();
+
+  /// 載入已儲存的偏好；未儲存時回傳 `false`。
+  static Future<bool> load() async {
+    return _preferences.getBool(_key) ?? false;
+  }
+
+  static Future<void> save(bool value) {
+    return _preferences.setBool(_key, value);
+  }
+}
+
+/// 目前是否為桌面平台（Web / 行動裝置不支援 always on top）。
+final isDesktopPlatformProvider = Provider<bool>((ref) {
+  return Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+});
+
+/// 初始 always-on-top 偏好。
+///
+/// 在 `bootstrap()` 中以從 SharedPreferences 載入的值覆寫，讓第一個畫面就
+/// 套用正確的釘選狀態。
+final initialAlwaysOnTopProvider = Provider<bool>((ref) => false);
+
+/// always-on-top 狀態。
+///
+/// 讀取 [initialAlwaysOnTopProvider] 作為初始值；[toggle] / [set] 同步更新
+/// state，再套用到桌面視窗並非同步寫入 [AlwaysOnTopStorage]。
+class AlwaysOnTopNotifier extends Notifier<bool> {
+  @override
+  bool build() => ref.read(initialAlwaysOnTopProvider);
+
+  Future<void> set(bool value) async {
+    if (state == value) {
+      return;
+    }
+
+    state = value;
+
+    if (ref.read(isDesktopPlatformProvider)) {
+      // setAlwaysOnTop 在非桌面平台會擲回例外，因此先以平台守衛擋住。
+      await windowManager.setAlwaysOnTop(value);
+    }
+
+    await AlwaysOnTopStorage.save(value);
+  }
+
+  Future<void> toggle() => set(!state);
+}
+
+final alwaysOnTopProvider =
+    NotifierProvider<AlwaysOnTopNotifier, bool>(AlwaysOnTopNotifier.new);

--- a/lib/app/always_on_top_settings.dart
+++ b/lib/app/always_on_top_settings.dart
@@ -14,7 +14,8 @@ class AlwaysOnTopStorage {
 
   /// 載入已儲存的偏好；未儲存時回傳 `false`。
   static Future<bool> load() async {
-    return _preferences.getBool(_key) ?? false;
+    final value = await _preferences.getBool(_key);
+    return value ?? false;
   }
 
   static Future<void> save(bool value) {

--- a/lib/app/always_on_top_settings.dart
+++ b/lib/app/always_on_top_settings.dart
@@ -1,8 +1,8 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
+
+import '../core/platform/platform_info.dart';
 
 /// 視窗「永遠置頂」(always on top / pin) 偏好是否已開啟。
 ///
@@ -24,8 +24,11 @@ class AlwaysOnTopStorage {
 }
 
 /// 目前是否為桌面平台（Web / 行動裝置不支援 always on top）。
+///
+/// 透過 [PlatformInfo.isDesktop] 判斷，避免在 Web 上存取 `dart:io` 的
+/// `Platform` 而擲回 `Unsupported operation`。
 final isDesktopPlatformProvider = Provider<bool>((ref) {
-  return Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+  return PlatformInfo.isDesktop;
 });
 
 /// 初始 always-on-top 偏好。

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,19 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/calculator/view/calculator_screen.dart';
 import 'theme.dart';
+import 'theme_settings.dart';
 
-class ScientificCalculatorApp extends StatelessWidget {
+class ScientificCalculatorApp extends ConsumerWidget {
   const ScientificCalculatorApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeSettingsProvider).themeMode;
+
     return MaterialApp(
       title: 'Scientific Calculator',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
-      themeMode: ThemeMode.system,
+      themeMode: themeMode,
       home: const CalculatorScreen(),
     );
   }

--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
+import 'theme_settings.dart';
 import 'windows_state.dart';
 
 Future<void> bootstrap() async {
@@ -53,7 +54,16 @@ Future<void> bootstrap() async {
     });
   }
 
+  // 預先載入主題偏好，讓第一個畫面就套用上次選擇的主題，避免啟動閃爍。
+  final initialThemePreference = await ThemeSettingsStorage.load();
+
   runApp(
-    ProviderScope(child: WindowStateObserver(child: ScientificCalculatorApp())),
+    ProviderScope(
+      overrides: [
+        initialThemePreferenceProvider
+            .overrideWith((ref) => initialThemePreference),
+      ],
+      child: WindowStateObserver(child: ScientificCalculatorApp()),
+    ),
   );
 }

--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
+import 'always_on_top_settings.dart';
 import 'theme_settings.dart';
 import 'windows_state.dart';
 
@@ -12,6 +13,9 @@ Future<void> bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   final isDesktop = Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+
+  // 預先載入 always-on-top 偏好；桌面平台會在視窗顯示前套用，避免閃爍。
+  final initialAlwaysOnTop = await AlwaysOnTopStorage.load();
 
   if (isDesktop) {
     await windowManager.ensureInitialized();
@@ -49,6 +53,9 @@ Future<void> bootstrap() async {
         }
       }
 
+      // 視窗顯示前套用 always-on-top，確保從一開始就維持釘選狀態。
+      await windowManager.setAlwaysOnTop(initialAlwaysOnTop);
+
       await windowManager.show();
       await windowManager.focus();
     });
@@ -60,8 +67,10 @@ Future<void> bootstrap() async {
   runApp(
     ProviderScope(
       overrides: [
-        initialThemePreferenceProvider
-            .overrideWith((ref) => initialThemePreference),
+        initialThemePreferenceProvider.overrideWith(
+          (ref) => initialThemePreference,
+        ),
+        initialAlwaysOnTopProvider.overrideWith((ref) => initialAlwaysOnTop),
       ],
       child: WindowStateObserver(child: ScientificCalculatorApp()),
     ),

--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -1,9 +1,8 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
 
+import '../core/platform/platform_info.dart';
 import 'app.dart';
 import 'always_on_top_settings.dart';
 import 'theme_settings.dart';
@@ -12,7 +11,7 @@ import 'windows_state.dart';
 Future<void> bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  final isDesktop = Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+  final isDesktop = PlatformInfo.isDesktop;
 
   // 預先載入 always-on-top 偏好；桌面平台會在視窗顯示前套用，避免閃爍。
   final initialAlwaysOnTop = await AlwaysOnTopStorage.load();

--- a/lib/app/package_info_providers.dart
+++ b/lib/app/package_info_providers.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// 應用程式封裝資訊（版本、建置編號）。
+final packageInfoProvider = FutureProvider<PackageInfo>((ref) {
+  return PackageInfo.fromPlatform();
+});

--- a/lib/app/theme_settings.dart
+++ b/lib/app/theme_settings.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 使用者選擇的佈景主題偏好。
+enum ThemePreference {
+  /// 跟隨系統設定。
+  system,
+
+  /// 淺色主題。
+  light,
+
+  /// 深色主題。
+  dark;
+
+  String get label {
+    return switch (this) {
+      ThemePreference.system => 'System',
+      ThemePreference.light => 'Light',
+      ThemePreference.dark => 'Dark',
+    };
+  }
+
+  ThemeMode get themeMode {
+    return switch (this) {
+      ThemePreference.system => ThemeMode.system,
+      ThemePreference.light => ThemeMode.light,
+      ThemePreference.dark => ThemeMode.dark,
+    };
+  }
+
+  /// 只接受已知的持久化字串；未知值或 `null` 一律回傳 [system]。
+  static ThemePreference fromName(String? name) {
+    return switch (name) {
+      'light' => ThemePreference.light,
+      'dark' => ThemePreference.dark,
+      _ => ThemePreference.system,
+    };
+  }
+}
+
+/// 以 SharedPreferences 持久化儲存主題偏好。
+///
+/// 沿用 [WindowStateStorage] 的 `SharedPreferencesAsync` 模式。
+class ThemeSettingsStorage {
+  static const _key = 'theme_preference';
+  static final SharedPreferencesAsync _preferences = SharedPreferencesAsync();
+
+  /// 載入已儲存的偏好；未儲存時回傳 [ThemePreference.system]。
+  static Future<ThemePreference> load() async {
+    final name = await _preferences.getString(_key);
+    return ThemePreference.fromName(name);
+  }
+
+  static Future<void> save(ThemePreference preference) {
+    return _preferences.setString(_key, preference.name);
+  }
+}
+
+/// 初始主題偏好。
+///
+/// 在 `bootstrap()` 中以從 SharedPreferences 載入的值覆寫，讓第一個畫面就套用
+/// 正確的主題，避免啟動時的閃爍。
+final initialThemePreferenceProvider = Provider<ThemePreference>(
+  (ref) => ThemePreference.system,
+);
+
+/// 主題偏好狀態。
+///
+/// 讀取 [initialThemePreferenceProvider] 作為初始值；[set] 同步更新 state，
+/// 再非同步寫入 [ThemeSettingsStorage]。
+class ThemeSettingsNotifier extends Notifier<ThemePreference> {
+  @override
+  ThemePreference build() => ref.read(initialThemePreferenceProvider);
+
+  Future<void> set(ThemePreference value) async {
+    if (state == value) {
+      return;
+    }
+    state = value;
+    await ThemeSettingsStorage.save(value);
+  }
+}
+
+final themeSettingsProvider =
+    NotifierProvider<ThemeSettingsNotifier, ThemePreference>(
+  ThemeSettingsNotifier.new,
+);

--- a/lib/app/windows_state.dart
+++ b/lib/app/windows_state.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
+
+import '../core/platform/platform_info.dart';
 
 class WindowStateData {
   const WindowStateData({required this.bounds, required this.isMaximized});
@@ -277,14 +278,11 @@ class _WindowStateObserverState extends State<WindowStateObserver>
   // 最後一個非最大化狀態的視窗範圍。
   Rect? _lastNormalBounds;
 
-  bool get _isDesktop =>
-      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
-
   @override
   void initState() {
     super.initState();
 
-    if (_isDesktop) {
+    if (PlatformInfo.isDesktop) {
       windowManager.addListener(this);
       unawaited(_captureInitialBounds());
     }
@@ -307,7 +305,7 @@ class _WindowStateObserverState extends State<WindowStateObserver>
   }
 
   Future<void> _saveWindowState() async {
-    if (!_isDesktop) {
+    if (!PlatformInfo.isDesktop) {
       return;
     }
 
@@ -366,7 +364,7 @@ class _WindowStateObserverState extends State<WindowStateObserver>
   void dispose() {
     _saveTimer?.cancel();
 
-    if (_isDesktop) {
+    if (PlatformInfo.isDesktop) {
       windowManager.removeListener(this);
     }
 

--- a/lib/core/platform/platform_info.dart
+++ b/lib/core/platform/platform_info.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart'
+    show kIsWeb, defaultTargetPlatform, TargetPlatform;
+
+/// 平台相關的輔助函式。
+///
+/// 重點：[dart:io] 的 `Platform` 在 Web 上不存在，存取任何
+/// `Platform.is*` 都會擲回 `Unsupported operation: Platform._operatingSystem`。
+/// 因此所有桌面平台判斷都必須先以 `kIsWeb` 短路擋住，再讀取 `Platform`。
+class PlatformInfo {
+  PlatformInfo._();
+
+  /// 是否為桌面平台（Windows / macOS / Linux）。
+  ///
+  /// 在 Web 與行動裝置上一律回傳 `false`。
+  static bool get isDesktop {
+    if (kIsWeb) {
+      return false;
+    }
+
+    return Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+  }
+
+  /// 目前是否為 Web 平台。
+  static bool get isWeb => kIsWeb;
+
+  /// 來自 Flutter 的目標平台；在 Web 上仍可安全讀取。
+  static bool get isMobile {
+    if (kIsWeb) {
+      return false;
+    }
+
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+  }
+}

--- a/lib/features/calculator/view/calculator_keyboard_input_enabled_provider.dart
+++ b/lib/features/calculator/view/calculator_keyboard_input_enabled_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/platform/platform_info.dart';
+
+/// 是否啟用硬體鍵盤輸入。
+///
+/// 只在桌面（Windows / macOS / Linux）與瀏覽器上啟用；行動裝置沒有硬體
+/// 鍵盤，攔截鍵盤事件沒有意義。
+final isKeyboardInputEnabledProvider = Provider<bool>((ref) {
+  return PlatformInfo.isDesktop || PlatformInfo.isWeb;
+});

--- a/lib/features/calculator/view/calculator_screen.dart
+++ b/lib/features/calculator/view/calculator_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../app/always_on_top_settings.dart';
 import '../viewmodel/calculator_providers.dart';
 import 'widgets/calculator_keypad.dart';
 import 'widgets/mode_indicator.dart';
 import 'widgets/natural_math_display.dart';
+import 'widgets/pin_button.dart';
 import 'widgets/result_display.dart';
 import 'widgets/settings_button.dart';
 
@@ -23,11 +25,15 @@ class CalculatorScreen extends ConsumerWidget {
       cursorVisible: !state.hasEvaluated,
     );
 
+    // 釘選 (always-on-top) 只在桌面平台提供。
+    final isDesktop = ref.watch(isDesktopPlatformProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Calculator'),
         centerTitle: false,
         actions: [
+          if (isDesktop) const PinButton(),
           Padding(
             padding: const EdgeInsets.only(right: 12),
             child: ModeIndicator(

--- a/lib/features/calculator/view/calculator_screen.dart
+++ b/lib/features/calculator/view/calculator_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../app/always_on_top_settings.dart';
 import '../viewmodel/calculator_providers.dart';
+import 'calculator_keyboard_input_enabled_provider.dart';
 import 'widgets/calculator_keypad.dart';
+import 'widgets/calculator_keyboard_listener.dart';
 import 'widgets/mode_indicator.dart';
 import 'widgets/natural_math_display.dart';
 import 'widgets/pin_button.dart';
@@ -28,26 +30,31 @@ class CalculatorScreen extends ConsumerWidget {
     // 釘選 (always-on-top) 只在桌面平台提供。
     final isDesktop = ref.watch(isDesktopPlatformProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Calculator'),
-        centerTitle: false,
-        actions: [
-          if (isDesktop) const PinButton(),
-          Padding(
-            padding: const EdgeInsets.only(right: 12),
-            child: ModeIndicator(
-              angleMode: state.angleMode,
-              onPressed: viewModel.toggleAngleMode,
+    // 硬體鍵盤輸入只在桌面 / 瀏覽器啟用。
+    final isKeyboardInputEnabled = ref.watch(isKeyboardInputEnabledProvider);
+
+    return CalculatorKeyboardListener(
+      enabled: isKeyboardInputEnabled,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Calculator'),
+          centerTitle: false,
+          actions: [
+            if (isDesktop) const PinButton(),
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: ModeIndicator(
+                angleMode: state.angleMode,
+                onPressed: viewModel.toggleAngleMode,
+              ),
             ),
-          ),
-          const Padding(
-            padding: EdgeInsets.only(right: 4),
-            child: SettingsButton(),
-          ),
-        ],
-      ),
-      body: SafeArea(
+            const Padding(
+              padding: EdgeInsets.only(right: 4),
+              child: SettingsButton(),
+            ),
+          ],
+        ),
+        body: SafeArea(
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 720),
@@ -108,6 +115,7 @@ class CalculatorScreen extends ConsumerWidget {
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/calculator/view/calculator_screen.dart
+++ b/lib/features/calculator/view/calculator_screen.dart
@@ -6,6 +6,7 @@ import 'widgets/calculator_keypad.dart';
 import 'widgets/mode_indicator.dart';
 import 'widgets/natural_math_display.dart';
 import 'widgets/result_display.dart';
+import 'widgets/settings_button.dart';
 
 class CalculatorScreen extends ConsumerWidget {
   const CalculatorScreen({super.key});
@@ -33,6 +34,10 @@ class CalculatorScreen extends ConsumerWidget {
               angleMode: state.angleMode,
               onPressed: viewModel.toggleAngleMode,
             ),
+          ),
+          const Padding(
+            padding: EdgeInsets.only(right: 4),
+            child: SettingsButton(),
           ),
         ],
       ),

--- a/lib/features/calculator/view/widgets/calculator_keyboard_listener.dart
+++ b/lib/features/calculator/view/widgets/calculator_keyboard_listener.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../viewmodel/calculator_providers.dart';
+import '../../viewmodel/calculator_view_model.dart';
+
+/// 鍵盤快速輸入處理器。
+///
+/// 將硬體鍵盤事件轉譯成對應的 [CalculatorViewModel] 方法。設計為純粹的
+/// 事件路由器：不持有狀態、不修改 Tree，全部交給 ViewModel，方便單元測試。
+///
+/// 支援的按鍵（與行動版 keypad 行為一致）：
+///
+/// - 數字 `0`-`9` -> [CalculatorViewModel.inputDigit]
+/// - `.` -> [CalculatorViewModel.inputDecimalPoint]
+/// - `+` / `-` / `*` / `/` -> 加減乘除
+/// - `(` / `)` -> 群組
+/// - `e` -> 歐拉數
+/// - `p` -> π（pi）
+/// - `?` -> 分數 `a/b`
+/// - `=` / `Enter` -> [CalculatorViewModel.calculate]
+/// - `Backspace` -> [CalculatorViewModel.backspace]
+/// - `Escape` -> [CalculatorViewModel.clear]
+/// - 方向鍵 -> 游標移動
+class CalculatorKeyboardHandler {
+  CalculatorKeyboardHandler(this.viewModel);
+
+  final CalculatorViewModel viewModel;
+
+  /// 處理單一鍵盤事件；回傳 `true` 表示已消耗（已對應到某個操作）。
+  ///
+  /// 呼叫端通常會在回傳 `true` 時呼叫 `KeyEventResult.handled`。
+  bool handle(KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return false;
+    }
+
+    final key = event.logicalKey;
+    final character = event.character;
+
+    // 1. 字元類按鍵：以 character 為主，能正確對應 shift 後的符號。
+    if (character != null && character.isNotEmpty) {
+      if (_handleCharacter(character)) {
+        return true;
+      }
+    }
+
+    // 2. 非字元類按鍵（Enter、Backspace、方向鍵等）以 logicalKey 判斷。
+    return _handleLogicalKey(key);
+  }
+
+  bool _handleCharacter(String char) {
+    switch (char) {
+      // 數字。
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        viewModel.inputDigit(char);
+        return true;
+
+      // 小數點。
+      case '.':
+      case ',':
+        viewModel.inputDecimalPoint();
+        return true;
+
+      // 四則運算。
+      case '+':
+        viewModel.inputAdd();
+        return true;
+      case '-':
+        viewModel.inputSubtract();
+        return true;
+      case '*':
+      case 'x':
+      case 'X':
+        viewModel.inputMultiply();
+        return true;
+      case '/':
+        viewModel.inputDivide();
+        return true;
+
+      // 括號。
+      case '(':
+        viewModel.inputOpenGroup();
+        return true;
+      case ')':
+        viewModel.inputCloseGroup();
+        return true;
+
+      // 常數。
+      case 'e':
+      case 'E':
+        viewModel.inputEulerNumber();
+        return true;
+      case 'p':
+      case 'P':
+        viewModel.inputPi();
+        return true;
+
+      // 分數 a/b。
+      case '?':
+        viewModel.inputFraction();
+        return true;
+      // 次方。
+      case '^':
+        viewModel.inputPower();
+        return true;
+
+      // sin
+      case 's':
+      case 'S':
+        viewModel.inputSin();
+        return true;
+
+      // cos
+      case 'c':
+      case 'C':
+        viewModel.inputCos();
+        return true;
+
+      // tan
+      case 't':
+      case 'T':
+        viewModel.inputTan();
+        return true;
+
+      // 計算。
+      case '=':
+        viewModel.calculate();
+        return true;
+    }
+
+    return false;
+  }
+
+  bool _handleLogicalKey(LogicalKeyboardKey key) {
+    if (key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter) {
+      viewModel.calculate();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.backspace) {
+      viewModel.backspace();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.escape) {
+      viewModel.clear();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      viewModel.moveLeft();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.arrowRight) {
+      viewModel.moveRight();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.arrowUp) {
+      viewModel.moveUp();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.arrowDown) {
+      viewModel.moveDown();
+      return true;
+    }
+
+    // Numpad 數字鍵（部份平台 / 瀏覽器不會產生 character）。
+    final digit = key.keyId; // 0x30..0x39 為 '0'..'9'
+    if (digit >= 0x30 && digit <= 0x39) {
+      viewModel.inputDigit(String.fromCharCode(digit));
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/// 包住子 widget，在桌面 / 瀏覽器環境下攔截硬體鍵盤輸入。
+///
+/// 行動裝置不會有硬體鍵盤事件，因此本 widget 只在
+/// [PlatformInfo.isDesktop] 或 Web 上安裝；其餘平台直接回傳 child。
+class CalculatorKeyboardListener extends ConsumerStatefulWidget {
+  const CalculatorKeyboardListener({
+    required this.child,
+    required this.enabled,
+    super.key,
+  });
+
+  final Widget child;
+
+  /// 是否啟用鍵盤輸入（呼叫端依平台判斷後傳入）。
+  final bool enabled;
+
+  @override
+  ConsumerState<CalculatorKeyboardListener> createState() =>
+      _CalculatorKeyboardListenerState();
+}
+
+class _CalculatorKeyboardListenerState
+    extends ConsumerState<CalculatorKeyboardListener> {
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    final viewModel = ref.read(calculatorViewModelProvider.notifier);
+    final handled = CalculatorKeyboardHandler(viewModel).handle(event);
+    return handled ? KeyEventResult.handled : KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) {
+      return widget.child;
+    }
+
+    return Focus(
+      focusNode: _focusNode,
+      autofocus: true,
+      onKeyEvent: _onKeyEvent,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/features/calculator/view/widgets/calculator_keypad.dart
+++ b/lib/features/calculator/view/widgets/calculator_keypad.dart
@@ -89,7 +89,7 @@ class CalculatorKeypad extends StatelessWidget {
           _key('(', onOpenParenthesis, CalculatorKeyStyle.function),
           _key(')', onCloseParenthesis, CalculatorKeyStyle.function),
 
-          _key('e', onEulerNumber, CalculatorKeyStyle.function),
+          _key('π', onPi, CalculatorKeyStyle.function),
           _key('÷', onDivide, CalculatorKeyStyle.operator),
         ]),
         _row([
@@ -113,7 +113,7 @@ class CalculatorKeypad extends StatelessWidget {
         _row([
           _digit('0'),
           _key('.', onDecimal, CalculatorKeyStyle.normal),
-          _key('π', onPi, CalculatorKeyStyle.function),
+          _key('e', onEulerNumber, CalculatorKeyStyle.function),
           _key('=', onCalculate, CalculatorKeyStyle.equals),
         ]),
       ],

--- a/lib/features/calculator/view/widgets/calculator_keypad.dart
+++ b/lib/features/calculator/view/widgets/calculator_keypad.dart
@@ -88,7 +88,7 @@ class CalculatorKeypad extends StatelessWidget {
         _row([
           _key('(', onOpenParenthesis, CalculatorKeyStyle.function),
           _key(')', onCloseParenthesis, CalculatorKeyStyle.function),
-          _key('π', onPi, CalculatorKeyStyle.function),
+
           _key('e', onEulerNumber, CalculatorKeyStyle.function),
           _key('÷', onDivide, CalculatorKeyStyle.operator),
         ]),
@@ -111,8 +111,9 @@ class CalculatorKeypad extends StatelessWidget {
           _key('+', onAdd, CalculatorKeyStyle.operator),
         ]),
         _row([
-          _digit('0', flex: 2),
+          _digit('0'),
           _key('.', onDecimal, CalculatorKeyStyle.normal),
+          _key('π', onPi, CalculatorKeyStyle.function),
           _key('=', onCalculate, CalculatorKeyStyle.equals),
         ]),
       ],

--- a/lib/features/calculator/view/widgets/pin_button.dart
+++ b/lib/features/calculator/view/widgets/pin_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../app/always_on_top_settings.dart';
+
+/// AppBar 上的「釘選 / 永遠置頂」按鈕。
+///
+/// 只在桌面平台（Windows / macOS / Linux）顯示，並以 Riverpod
+/// [alwaysOnTopProvider] 驅動視窗的 always-on-top 狀態。
+class PinButton extends ConsumerWidget {
+  const PinButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isPinned = ref.watch(alwaysOnTopProvider);
+    final notifier = ref.read(alwaysOnTopProvider.notifier);
+
+    return IconButton(
+      icon: Icon(
+        // 已釘選時使用實心圖釘；未釘選時使用外框圖釘。
+        isPinned ? Icons.push_pin : Icons.push_pin_outlined,
+        // 釘選時強調顏色，讓使用者一眼看出目前的狀態。
+        color: isPinned ? Theme.of(context).colorScheme.primary : null,
+      ),
+      tooltip: isPinned ? 'Unpin (always on top)' : 'Pin on top',
+      onPressed: notifier.toggle,
+    );
+  }
+}

--- a/lib/features/calculator/view/widgets/settings_button.dart
+++ b/lib/features/calculator/view/widgets/settings_button.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import 'settings_dialog.dart';
+
+/// AppBar 上的設定按鈕；點擊後開啟設定對話框。
+class SettingsButton extends StatelessWidget {
+  const SettingsButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.settings),
+      tooltip: 'Settings',
+      onPressed: () => showSettingsDialog(context),
+    );
+  }
+}

--- a/lib/features/calculator/view/widgets/settings_dialog.dart
+++ b/lib/features/calculator/view/widgets/settings_dialog.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../app/package_info_providers.dart';
+import '../../../../app/theme_settings.dart';
+
+/// 設定對話框：切換主題、顯示版本資訊。
+Future<void> showSettingsDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => const _SettingsDialog(),
+  );
+}
+
+class _SettingsDialog extends ConsumerWidget {
+  const _SettingsDialog();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final current = ref.watch(themeSettingsProvider);
+    final notifier = ref.read(themeSettingsProvider.notifier);
+
+    return AlertDialog(
+      title: const Text('Settings'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Theme',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            for (final preference in ThemePreference.values)
+              RadioListTile<ThemePreference>(
+                value: preference,
+                groupValue: current,
+                title: Text(preference.label),
+                onChanged: (value) {
+                  if (value != null) {
+                    notifier.set(value);
+                  }
+                },
+              ),
+            const Divider(),
+            ListTile(
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                'Version',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              subtitle: const _VersionText(),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+class _VersionText extends ConsumerWidget {
+  const _VersionText();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncInfo = ref.watch(packageInfoProvider);
+
+    return asyncInfo.when(
+      loading: () => const Text('—'),
+      error: (_, __) => const Text('—'),
+      data: (info) => Text('${info.version} (build ${info.buildNumber})'),
+    );
+  }
+}

--- a/test/app/theme_settings_test.dart
+++ b/test/app/theme_settings_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/app/theme_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 主題偏好持久化與 Notifier 測試。
+void main() {
+  group('ThemePreference', () {
+    test('label 與 themeMode 對應', () {
+      expect(ThemePreference.system.label, 'System');
+      expect(ThemePreference.system.themeMode, ThemeMode.system);
+
+      expect(ThemePreference.light.label, 'Light');
+      expect(ThemePreference.light.themeMode, ThemeMode.light);
+
+      expect(ThemePreference.dark.label, 'Dark');
+      expect(ThemePreference.dark.themeMode, ThemeMode.dark);
+    });
+
+    test('fromName 只接受已知值，其餘回傳 system', () {
+      expect(ThemePreference.fromName('light'), ThemePreference.light);
+      expect(ThemePreference.fromName('dark'), ThemePreference.dark);
+      expect(ThemePreference.fromName('system'), ThemePreference.system);
+      expect(ThemePreference.fromName(null), ThemePreference.system);
+      expect(ThemePreference.fromName('garbage'), ThemePreference.system);
+    });
+  });
+
+  group('ThemeSettingsStorage', () {
+    setUp(SharedPreferences.setMockInitialValues);
+
+    test('未儲存時 load 回傳 system', () async {
+      expect(await ThemeSettingsStorage.load(), ThemePreference.system);
+    });
+
+    test('save 後可 load 回相同值', () async {
+      await ThemeSettingsStorage.save(ThemePreference.dark);
+      expect(await ThemeSettingsStorage.load(), ThemePreference.dark);
+
+      await ThemeSettingsStorage.save(ThemePreference.light);
+      expect(await ThemeSettingsStorage.load(), ThemePreference.light);
+    });
+  });
+
+  group('ThemeSettingsNotifier', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues();
+      container = ProviderContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    test('初始值預設為 system', () {
+      expect(
+        container.read(themeSettingsProvider),
+        ThemePreference.system,
+      );
+    });
+
+    test('initialThemePreferenceProvider override 可改變初始值', () {
+      final overridden = ProviderContainer(
+        overrides: [
+          initialThemePreferenceProvider
+              .overrideWith((ref) => ThemePreference.dark),
+        ],
+      );
+      addTearDown(overridden.dispose);
+
+      expect(overridden.read(themeSettingsProvider), ThemePreference.dark);
+    });
+
+    test('set 更新 state 並持久化', () async {
+      final notifier = container.read(themeSettingsProvider.notifier);
+
+      await notifier.set(ThemePreference.light);
+
+      expect(container.read(themeSettingsProvider), ThemePreference.light);
+      expect(await ThemeSettingsStorage.load(), ThemePreference.light);
+    });
+
+    test('set 相同值不重複寫入', () async {
+      final notifier = container.read(themeSettingsProvider.notifier);
+
+      await notifier.set(ThemePreference.system);
+
+      // state 不變，且未寫入（load 仍為預設 system，無副作用可觀測）。
+      expect(container.read(themeSettingsProvider), ThemePreference.system);
+    });
+  });
+}

--- a/test/features/calculator/view/widgets/calculator_keyboard_listener_test.dart
+++ b/test/features/calculator/view/widgets/calculator_keyboard_listener_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/constant_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/fraction_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/group_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/number_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/operator_node.dart';
+import 'package:scientific_calculator/features/calculator/view/widgets/calculator_keyboard_listener.dart';
+import 'package:scientific_calculator/features/calculator/viewmodel/calculator_providers.dart';
+import 'package:scientific_calculator/features/calculator/viewmodel/calculator_view_model.dart';
+
+/// 鍵盤處理器測試：驗證硬體鍵盤事件正確對應到 ViewModel 方法。
+void main() {
+  late ProviderContainer container;
+  late CalculatorKeyboardHandler handler;
+
+  setUp(() {
+    container = ProviderContainer();
+    final viewModel = container.read(calculatorViewModelProvider.notifier);
+    handler = CalculatorKeyboardHandler(viewModel);
+  });
+
+  tearDown(() => container.dispose());
+
+  CalculatorViewModel viewModel() =>
+      container.read(calculatorViewModelProvider.notifier);
+
+  /// 以 character + logicalKey 合成 KeyDownEvent，並回傳是否已處理。
+  bool press({
+    String? character,
+    LogicalKeyboardKey logicalKey = LogicalKeyboardKey.space,
+  }) {
+    final event = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.space,
+      logicalKey: logicalKey,
+      timeStamp: Duration.zero,
+      character: character,
+    );
+    return handler.handle(event);
+  }
+
+  group('CalculatorKeyboardHandler 數字 / 小數點', () {
+    test('0-9 對應 inputDigit', () {
+      for (var d = 0; d <= 9; d++) {
+        press(character: d.toString());
+      }
+      final node =
+          viewModel().state.document.root.children.first as NumberNode;
+      expect(node.value, '0123456789');
+    });
+
+    test('Numpad 數字（無 character）也能輸入', () {
+      // 模擬部份瀏覽器不產生 character 的 numpad。
+      press(logicalKey: LogicalKeyboardKey(0x31)); // '1'
+      press(logicalKey: LogicalKeyboardKey(0x32)); // '2'
+      press(logicalKey: LogicalKeyboardKey(0x33)); // '3'
+      final node =
+          viewModel().state.document.root.children.first as NumberNode;
+      expect(node.value, '123');
+    });
+
+    test('. 輸入小數點', () {
+      press(character: '1');
+      press(character: '.');
+      press(character: '5');
+      final node =
+          viewModel().state.document.root.children.first as NumberNode;
+      expect(node.value, '1.5');
+    });
+  });
+
+  group('CalculatorKeyboardHandler 四則運算', () {
+    test('+ - * / 各自對應正確 operator', () {
+      press(character: '1');
+      press(character: '+');
+      expect(
+        (viewModel().state.document.root.children[1] as OperatorNode)
+            .operator,
+        ExpressionOperator.add,
+      );
+
+      viewModel().clear();
+      press(character: '1');
+      press(character: '-');
+      expect(
+        (viewModel().state.document.root.children[1] as OperatorNode)
+            .operator,
+        ExpressionOperator.subtract,
+      );
+
+      viewModel().clear();
+      press(character: '1');
+      press(character: '*');
+      expect(
+        (viewModel().state.document.root.children[1] as OperatorNode)
+            .operator,
+        ExpressionOperator.multiply,
+      );
+
+      viewModel().clear();
+      press(character: '1');
+      press(character: '/');
+      expect(
+        (viewModel().state.document.root.children[1] as OperatorNode)
+            .operator,
+        ExpressionOperator.divide,
+      );
+    });
+
+    test('x 與 X 也對應乘法', () {
+      press(character: '2');
+      press(character: 'x');
+      expect(
+        (viewModel().state.document.root.children[1] as OperatorNode)
+            .operator,
+        ExpressionOperator.multiply,
+      );
+    });
+  });
+
+  group('CalculatorKeyboardHandler 括號 / 常數 / 分數', () {
+    test('( 與 ) 建立 Group', () {
+      press(character: '(');
+      expect(
+        viewModel().state.document.root.children.first,
+        isA<GroupNode>(),
+      );
+
+      viewModel().clear();
+      press(character: ')');
+      expect(
+        viewModel().state.document.root.children.first,
+        isA<GroupNode>(),
+      );
+    });
+
+    test('e 對應歐拉數常數', () {
+      press(character: 'e');
+      final node = viewModel().state.document.root.children.first;
+      expect(node, isA<ConstantNode>());
+      expect((node as ConstantNode).constant, MathConstant.e);
+    });
+
+    test('p 對應 π 常數', () {
+      press(character: 'p');
+      final node = viewModel().state.document.root.children.first;
+      expect(node, isA<ConstantNode>());
+      expect((node as ConstantNode).constant, MathConstant.pi);
+    });
+
+    test('? 對應分數 a/b', () {
+      press(character: '?');
+      expect(
+        viewModel().state.document.root.children.first,
+        isA<FractionNode>(),
+      );
+    });
+  });
+
+  group('CalculatorKeyboardHandler 計算 / 編輯鍵', () {
+    test('= 觸發 calculate', () {
+      press(character: '2');
+      press(character: '+');
+      press(character: '3');
+      press(character: '=');
+      expect(viewModel().state.hasEvaluated, isTrue);
+      expect(viewModel().state.result?.value, 5);
+    });
+
+    test('Enter 觸發 calculate', () {
+      press(character: '2');
+      press(character: '+');
+      press(character: '3');
+      press(logicalKey: LogicalKeyboardKey.enter);
+      expect(viewModel().state.hasEvaluated, isTrue);
+    });
+
+    test('Backspace 觸發 backspace', () {
+      press(character: '1');
+      press(character: '2');
+      expect(
+        (viewModel().state.document.root.children.first as NumberNode).value,
+        '12',
+      );
+      press(logicalKey: LogicalKeyboardKey.backspace);
+      expect(
+        (viewModel().state.document.root.children.first as NumberNode).value,
+        '1',
+      );
+    });
+
+    test('Escape 觸發 clear', () {
+      press(character: '1');
+      press(character: '+');
+      press(logicalKey: LogicalKeyboardKey.escape);
+      expect(viewModel().state.document.root.children, isEmpty);
+    });
+  });
+
+  group('CalculatorKeyboardHandler 方向鍵', () {
+    test('方向鍵不輸入新 node，只移動游標', () {
+      press(character: '1');
+      press(character: '+');
+      press(character: '2');
+
+      final countBefore = viewModel().state.document.root.children.length;
+      press(logicalKey: LogicalKeyboardKey.arrowLeft);
+      press(logicalKey: LogicalKeyboardKey.arrowRight);
+      press(logicalKey: LogicalKeyboardKey.arrowUp);
+      press(logicalKey: LogicalKeyboardKey.arrowDown);
+      expect(
+        viewModel().state.document.root.children.length,
+        countBefore,
+      );
+    });
+  });
+
+  group('CalculatorKeyboardHandler 未對應的鍵', () {
+    test('未對應的字元回傳 false（例如 q）', () {
+      final result = handler.handle(
+        KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.keyQ,
+          logicalKey: LogicalKeyboardKey.keyQ,
+          timeStamp: Duration.zero,
+          character: 'q',
+        ),
+      );
+      expect(result, isFalse);
+      expect(viewModel().state.document.root.children, isEmpty);
+    });
+
+    test('非 KeyDownEvent（如 KeyRepeatEvent）不處理', () {
+      final event = KeyRepeatEvent(
+        physicalKey: PhysicalKeyboardKey.digit1,
+        logicalKey: LogicalKeyboardKey.digit1,
+        timeStamp: Duration.zero,
+        character: '1',
+      );
+      expect(handler.handle(event), isFalse);
+    });
+  });
+}

--- a/test/features/calculator/view/widgets/settings_dialog_test.dart
+++ b/test/features/calculator/view/widgets/settings_dialog_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:scientific_calculator/app/package_info_providers.dart';
+import 'package:scientific_calculator/app/theme_settings.dart';
+import 'package:scientific_calculator/features/calculator/view/widgets/settings_button.dart';
+import 'package:scientific_calculator/features/calculator/view/widgets/settings_dialog.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 設定對話框 widget 測試。
+void main() {
+  setUp(SharedPreferences.setMockInitialValues);
+
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    List<Override> overrides = const [],
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () => showSettingsDialog(context),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('顯示三個主題選項與版本區塊', (tester) async {
+    await pumpDialog(
+      tester,
+      overrides: [
+        packageInfoProvider.overrideWith(
+          (ref) async => PackageInfo(
+            appName: 'Scientific Calculator',
+            packageName: 'scientific_calculator',
+            version: '1.0.0',
+            buildNumber: '1',
+            buildSignature: '',
+            installerStore: null,
+          ),
+        ),
+      ],
+    );
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('System'), findsOneWidget);
+    expect(find.text('Light'), findsOneWidget);
+    expect(find.text('Dark'), findsOneWidget);
+    expect(find.text('Version'), findsOneWidget);
+    expect(find.text('1.0.0 (build 1)'), findsOneWidget);
+  });
+
+  testWidgets('預設選中 System，點 Light 後切換狀態', (tester) async {
+    await pumpDialog(
+      tester,
+      overrides: [
+        packageInfoProvider.overrideWith((ref) async => _emptyPackageInfo()),
+      ],
+    );
+
+    // 初始：System RadioListTile 為已選。
+    final systemRadio =
+        find.widgetWithText(RadioListTile<ThemePreference>, 'System');
+    expect(
+      tester.widget<RadioListTile<ThemePreference>>(systemRadio).groupValue,
+      ThemePreference.system,
+    );
+
+    // 點 Light。
+    await tester.tap(find.text('Light'));
+    await tester.pump();
+
+    // 切換後：Light RadioListTile 為已選。
+    final lightRadio =
+        find.widgetWithText(RadioListTile<ThemePreference>, 'Light');
+    expect(
+      tester.widget<RadioListTile<ThemePreference>>(lightRadio).groupValue,
+      ThemePreference.light,
+    );
+  });
+
+  testWidgets('Close 按鈕關閉對話框', (tester) async {
+    await pumpDialog(
+      tester,
+      overrides: [
+        packageInfoProvider.overrideWith((ref) async => _emptyPackageInfo()),
+      ],
+    );
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsNothing);
+  });
+
+  testWidgets('SettingsButton 點擊後開啟對話框', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          packageInfoProvider.overrideWith((ref) async => _emptyPackageInfo()),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: SettingsButton()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(SettingsButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsOneWidget);
+  });
+}
+
+PackageInfo _emptyPackageInfo() {
+  return PackageInfo(
+    appName: '',
+    packageName: '',
+    version: '1.0.0',
+    buildNumber: '1',
+    buildSignature: '',
+    installerStore: null,
+  );
+}


### PR DESCRIPTION
This pull request introduces a new user theme selection and persistence system, adds a settings dialog to the calculator app, and implements platform-aware logic for desktop-specific features. The main changes are the addition of a theme switcher with persistent storage, a settings dialog showing the app version, and improved platform detection to avoid runtime errors on unsupported platforms. The codebase is refactored to ensure correct theme and window state application on app startup, and new providers and tests are added to support these features.

**Theme selection and persistence:**
- Added `ThemePreference` enum and `ThemeSettingsStorage` for storing theme preference in `SharedPreferences`, plus a Riverpod `Notifier` for theme state (`themeSettingsProvider`). The app now loads and applies the saved theme before the first frame to avoid flicker. (`lib/app/theme_settings.dart`, `.zcode/plans/plan-sess_bbd72b49-68e6-4b9f-bd90-cedce92575dd.md`, [[1]](diffhunk://#diff-645da16249feeadb0ad48db45b56811b99433e963153bfc7d6514c19c547c1a3R1-R88) [[2]](diffhunk://#diff-00c3ced8fe685da3cf40944a0cf4c716de8c969121b17a3eebc5c3aa7d008e4fR2-R20) [[3]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3L1-R17) [[4]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3R55-R75)

**Settings dialog and UI integration:**
- Added a settings button to the app bar (next to DEG/RAD), which opens a dialog allowing theme selection (System/Light/Dark) and displays the app version (using `package_info_plus`). (`.zcode/plans/plan-sess_bbd72b49-68e6-4b9f-bd90-cedce92575dd.md`)

**Platform-aware desktop features:**
- Implemented `PlatformInfo` utility to safely detect desktop, web, and mobile platforms without runtime errors on the web. Refactored all platform checks to use this utility instead of `dart:io` directly. (`lib/core/platform/platform_info.dart`, [lib/core/platform/platform_info.dartR1-R37](diffhunk://#diff-55901583a912f62562fda072b8a0170e3b3e6a9adbdb1ba94cb11f2a7426db76R1-R37))
- Added always-on-top (window pin) state persistence and Riverpod integration, only enabled on desktop platforms. (`lib/app/always_on_top_settings.dart`, [[1]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3L1-R17) [[2]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3R55-R75) [[3]](diffhunk://#diff-4094418981490153bb6f7430bd8f628ae383543912187f57eb67e06cb3d762fcL2-R9) [[4]](diffhunk://#diff-4094418981490153bb6f7430bd8f628ae383543912187f57eb67e06cb3d762fcL280-R285) [[5]](diffhunk://#diff-4094418981490153bb6f7430bd8f628ae383543912187f57eb67e06cb3d762fcL310-R308) [[6]](diffhunk://#diff-4094418981490153bb6f7430bd8f628ae383543912187f57eb67e06cb3d762fcL369-R367)

**Calculator screen enhancements:**
- Added `SettingsButton` and desktop-only `PinButton` to the app bar, and enabled hardware keyboard input only on desktop/web platforms. (`lib/features/calculator/view/calculator_screen.dart`, [[1]](diffhunk://#diff-d9fd02c215aa73de0ba48fbfb6478e74bbd2d04acd0d5694cb2ecef035f2939bR4-R13) [[2]](diffhunk://#diff-d9fd02c215aa73de0ba48fbfb6478e74bbd2d04acd0d5694cb2ecef035f2939bL25-R54) [[3]](diffhunk://#diff-d9fd02c215aa73de0ba48fbfb6478e74bbd2d04acd0d5694cb2ecef035f2939bR119) [[4]](diffhunk://#diff-51dbff9cfccc6f7e2327fd0faee8069b0825dbebb0a15420967a3db50e060e9eR1-R11)

**App version provider:**
- Added a Riverpod `FutureProvider` for accessing the app's version and build number at runtime. (`lib/app/package_info_providers.dart`, [lib/app/package_info_providers.dartR1-R7](diffhunk://#diff-38bc537a9f45a1a1ca6046d97b3ea0dc370efe3685cf3daeccd98474ba744fa1R1-R7))