### PR TITLE
Migrate settings UI/tests to RadioGroup

### DIFF
--- a/lib/features/calculator/view/widgets/settings_dialog.dart
+++ b/lib/features/calculator/view/widgets/settings_dialog.dart
@@ -31,17 +31,25 @@ class _SettingsDialog extends ConsumerWidget {
               'Theme',
               style: Theme.of(context).textTheme.titleSmall,
             ),
-            for (final preference in ThemePreference.values)
-              RadioListTile<ThemePreference>(
-                value: preference,
-                groupValue: current,
-                title: Text(preference.label),
-                onChanged: (value) {
-                  if (value != null) {
-                    notifier.set(value);
-                  }
-                },
+            // RadioGroup 集中管理 groupValue 與 onChanged（Flutter 3.32+ 後
+            // RadioListTile.groupValue / onChanged 已棄用）。
+            RadioGroup<ThemePreference>(
+              groupValue: current,
+              onChanged: (value) {
+                if (value != null) {
+                  notifier.set(value);
+                }
+              },
+              child: Column(
+                children: [
+                  for (final preference in ThemePreference.values)
+                    RadioListTile<ThemePreference>(
+                      value: preference,
+                      title: Text(preference.label),
+                    ),
+                ],
               ),
+            ),
             const Divider(),
             ListTile(
               dense: true,
@@ -74,7 +82,7 @@ class _VersionText extends ConsumerWidget {
 
     return asyncInfo.when(
       loading: () => const Text('—'),
-      error: (_, __) => const Text('—'),
+      error: (_, _) => const Text('—'),
       data: (info) => Text('${info.version} (build ${info.buildNumber})'),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -601,7 +601,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,12 +52,16 @@ dev_dependencies:
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
+  # package. See that file for information on deactivating specific lint rules
+  # and activating additional ones.
   flutter_lints: ^6.0.0
 
   flutter_launcher_icons: ^0.14.3
   rename_app: ^1.6.6
+  # 測試 SharedPreferencesAsync 時需要直接註冊 in-memory 平台實作；
+  # 此套件為 shared_preferences 的 transitive dependency，這裡明確宣告為
+  # dev_dependency 以避免 pub upgrade 後被移除。
+  shared_preferences_platform_interface: ^2.4.2
 
 flutter_launcher_icons:
   android: true

--- a/test/app/theme_settings_test.dart
+++ b/test/app/theme_settings_test.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:scientific_calculator/app/theme_settings.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/shared_preferences_test_helper.dart';
 
 /// 主題偏好持久化與 Notifier 測試。
 void main() {
@@ -28,7 +29,7 @@ void main() {
   });
 
   group('ThemeSettingsStorage', () {
-    setUp(SharedPreferences.setMockInitialValues);
+    setUp(setupSharedPreferencesForTest);
 
     test('未儲存時 load 回傳 system', () async {
       expect(await ThemeSettingsStorage.load(), ThemePreference.system);
@@ -47,7 +48,7 @@ void main() {
     late ProviderContainer container;
 
     setUp(() {
-      SharedPreferences.setMockInitialValues();
+      setupSharedPreferencesForTest();
       container = ProviderContainer();
     });
 

--- a/test/features/calculator/view/widgets/settings_dialog_test.dart
+++ b/test/features/calculator/view/widgets/settings_dialog_test.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:scientific_calculator/app/package_info_providers.dart';
 import 'package:scientific_calculator/app/theme_settings.dart';
 import 'package:scientific_calculator/features/calculator/view/widgets/settings_button.dart';
 import 'package:scientific_calculator/features/calculator/view/widgets/settings_dialog.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../../helpers/shared_preferences_test_helper.dart';
 
 /// 設定對話框 widget 測試。
 void main() {
-  setUp(SharedPreferences.setMockInitialValues);
+  setUp(setupSharedPreferencesForTest);
 
   Future<void> pumpDialog(
     WidgetTester tester, {
@@ -71,25 +73,22 @@ void main() {
       ],
     );
 
-    // 初始：System RadioListTile 為已選。
-    final systemRadio =
-        find.widgetWithText(RadioListTile<ThemePreference>, 'System');
-    expect(
-      tester.widget<RadioListTile<ThemePreference>>(systemRadio).groupValue,
-      ThemePreference.system,
-    );
+    // 群組值現在由 RadioGroup 祖先持有（RadioListTile.groupValue 已棄用）。
+    ThemePreference groupValue() => tester
+        .widget<RadioGroup<ThemePreference>>(
+          find.byType(RadioGroup<ThemePreference>),
+        )
+        .groupValue!;
+
+    // 初始：選中 System。
+    expect(groupValue(), ThemePreference.system);
 
     // 點 Light。
     await tester.tap(find.text('Light'));
     await tester.pump();
 
-    // 切換後：Light RadioListTile 為已選。
-    final lightRadio =
-        find.widgetWithText(RadioListTile<ThemePreference>, 'Light');
-    expect(
-      tester.widget<RadioListTile<ThemePreference>>(lightRadio).groupValue,
-      ThemePreference.light,
-    );
+    // 切換後：選中 Light。
+    expect(groupValue(), ThemePreference.light);
   });
 
   testWidgets('Close 按鈕關閉對話框', (tester) async {

--- a/test/helpers/shared_preferences_test_helper.dart
+++ b/test/helpers/shared_preferences_test_helper.dart
@@ -1,0 +1,23 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// 為測試安裝 SharedPreferences 的 mock 平台實作。
+///
+/// `SharedPreferences.setMockInitialValues({})` 只會註冊「舊版」
+/// ([SharedPreferencesStorePlatform]) 的 in-memory store；但專案使用的是
+/// `SharedPreferencesAsync`，它依賴另一個獨立的 singleton
+/// `SharedPreferencesAsyncPlatform.instance`，未註冊時會擲回
+/// `Bad state: The SharedPreferencesAsyncPlatform instance must be set.`。
+///
+/// 此 helper 同時安裝兩者，讓涉及 [SharedPreferencesAsync] 的測試能正確執行。
+void setupSharedPreferencesForTest([Map<String, Object>? initial]) {
+  // 舊版 store（保留舊測試行為）。
+  SharedPreferences.setMockInitialValues(initial ?? const <String, Object>{});
+
+  // 新版 async 平台；每次 setUp 重新建立，避免跨測試殘留資料。
+  SharedPreferencesAsyncPlatform.instance =
+      initial == null || initial.isEmpty
+          ? InMemorySharedPreferencesAsync.empty()
+          : InMemorySharedPreferencesAsync.withData(initial);
+}


### PR DESCRIPTION
Refactors the settings dialog to use `RadioGroup` as `RadioListTile.groupValue/onChanged` are deprecated, and updates widget tests to assert selection via the group state. Also adds a shared test helper that installs both legacy `SharedPreferences` mocks and `SharedPreferencesAsync` in-memory platform instances, then reuses it across tests to prevent async platform initialization failures.