### PR TITLE
Enhance FRAC results and enforce APK signing for Android release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -74,9 +74,14 @@ jobs:
           echo "Release title: ${RELEASE_TITLE}"
 
   build-android:
-    name: Build Android APK
+    name: Build Signed Android APK
     runs-on: ubuntu-latest
-    needs: prepare-version
+
+    needs:
+      - prepare-version
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -86,7 +91,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "25"
+          java-version: "17"
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -100,9 +105,144 @@ jobs:
       - name: Show build information
         shell: bash
         run: |
+          set -euo pipefail
+
           echo "Application name: ${APP_NAME}"
           echo "Application version: ${{ needs.prepare-version.outputs.app-version }}"
           echo "Build number: ${{ needs.prepare-version.outputs.build-number }}"
+
+      # 如果任何 Secret 缺失，立即停止。
+      # 絕不回退至 debug signing。
+      - name: Validate Android signing secrets
+        shell: bash
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          missing_secrets=()
+
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            missing_secrets+=("ANDROID_KEYSTORE_BASE64")
+          fi
+
+          if [ -z "$KEYSTORE_PASSWORD" ]; then
+            missing_secrets+=("ANDROID_KEYSTORE_PASSWORD")
+          fi
+
+          if [ -z "$KEY_ALIAS" ]; then
+            missing_secrets+=("ANDROID_KEY_ALIAS")
+          fi
+
+          if [ -z "$KEY_PASSWORD" ]; then
+            missing_secrets+=("ANDROID_KEY_PASSWORD")
+          fi
+
+          if [ "${#missing_secrets[@]}" -gt 0 ]; then
+            echo "::error::以下 Android signing secrets 缺失："
+
+            for secret_name in "${missing_secrets[@]}"; do
+              echo "::error::  - $secret_name"
+            done
+
+            exit 1
+          fi
+
+          echo "Android signing secrets 已設定。"
+
+      # 還原為 android/android-release.jks
+      - name: Restore Android release keystore
+        shell: bash
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          KEYSTORE_PATH="$GITHUB_WORKSPACE/android/android-release.jks"
+
+          rm -f "$KEYSTORE_PATH"
+
+          printf '%s' "$KEYSTORE_BASE64" |
+            base64 --decode \
+            > "$KEYSTORE_PATH"
+
+          chmod 600 "$KEYSTORE_PATH"
+
+          if [ ! -s "$KEYSTORE_PATH" ]; then
+            echo "::error::還原後的 Android keystore 不存在或檔案大小為 0。"
+            exit 1
+          fi
+
+          echo "Android release keystore 已成功還原。"
+          ls -lh "$KEYSTORE_PATH"
+
+      # 動態建立 android/key.properties
+      - name: Create Android key.properties
+        shell: bash
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          PROPERTIES_PATH="$GITHUB_WORKSPACE/android/key.properties"
+
+          rm -f "$PROPERTIES_PATH"
+
+          {
+            printf 'storePassword=%s\n' "$KEYSTORE_PASSWORD"
+            printf 'keyPassword=%s\n' "$KEY_PASSWORD"
+            printf 'keyAlias=%s\n' "$KEY_ALIAS"
+            printf 'storeFile=%s\n' "android-release.jks"
+          } > "$PROPERTIES_PATH"
+
+          chmod 600 "$PROPERTIES_PATH"
+
+          if [ ! -s "$PROPERTIES_PATH" ]; then
+            echo "::error::android/key.properties 建立失敗。"
+            exit 1
+          fi
+
+          # 不輸出任何密碼。
+          echo "android/key.properties 已建立。"
+          echo "keyAlias=$KEY_ALIAS"
+          echo "storeFile=android-release.jks"
+
+      # 在 Flutter build 前驗證 JKS 密碼和 alias。
+      - name: Verify Android release keystore
+        shell: bash
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+
+          KEYSTORE_PATH="$GITHUB_WORKSPACE/android/android-release.jks"
+          KEYSTORE_INFORMATION="$RUNNER_TEMP/android-keystore-information.txt"
+
+          keytool \
+            -list \
+            -keystore "$KEYSTORE_PATH" \
+            -storepass "$KEYSTORE_PASSWORD" \
+            -alias "$KEY_ALIAS" \
+            -v \
+            > "$KEYSTORE_INFORMATION"
+
+          if ! grep -Fq "PrivateKeyEntry" "$KEYSTORE_INFORMATION"; then
+            echo "::error::指定 alias 不是有效的 PrivateKeyEntry。"
+            exit 1
+          fi
+
+          echo "Android release keystore 驗證成功。"
+          echo "Alias: $KEY_ALIAS"
+
+          grep -E "SHA256:|SHA-256:" \
+            "$KEYSTORE_INFORMATION" \
+            || true
 
       - name: Install dependencies
         run: flutter pub get
@@ -110,11 +250,11 @@ jobs:
       - name: Analyze project
         run: flutter analyze
 
-      # 專案具備可正常執行的 tests 後，可取消註解。
+      # 專案具備 tests 後可啟用。
       # - name: Run tests
       #   run: flutter test
 
-      - name: Build release APK
+      - name: Build signed release APK
         shell: bash
         run: |
           set -euo pipefail
@@ -123,6 +263,110 @@ jobs:
             --release \
             --build-name="${{ needs.prepare-version.outputs.app-version }}" \
             --build-number="${{ needs.prepare-version.outputs.build-number }}"
+
+      # 驗證 APK 確實使用指定 JKS 簽署。
+      - name: Verify APK signature and signing certificate
+        shell: bash
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+
+          APK_PATH="$GITHUB_WORKSPACE/build/app/outputs/flutter-apk/app-release.apk"
+          KEYSTORE_PATH="$GITHUB_WORKSPACE/android/android-release.jks"
+          APK_SIGNATURE_OUTPUT="$RUNNER_TEMP/apk-signature.txt"
+
+          if [ ! -s "$APK_PATH" ]; then
+            echo "::error::找不到 release APK 或檔案大小為 0：$APK_PATH"
+            exit 1
+          fi
+
+          if [ ! -s "$KEYSTORE_PATH" ]; then
+            echo "::error::找不到 Android release keystore：$KEYSTORE_PATH"
+            exit 1
+          fi
+
+          APKSIGNER="$(
+            find "$ANDROID_HOME/build-tools" \
+              -type f \
+              -name apksigner \
+              -print |
+            sort -V |
+            tail -n 1
+          )"
+
+          if [ -z "$APKSIGNER" ] || [ ! -x "$APKSIGNER" ]; then
+            echo "::error::找不到 Android SDK apksigner。"
+            exit 1
+          fi
+
+          echo "使用 apksigner：$APKSIGNER"
+
+          "$APKSIGNER" verify \
+            --verbose \
+            --print-certs \
+            "$APK_PATH" |
+            tee "$APK_SIGNATURE_OUTPUT"
+
+          APK_SHA256="$(
+            awk -F': ' '
+              /certificate SHA-256 digest:/ {
+                print $NF
+                exit
+              }
+            ' "$APK_SIGNATURE_OUTPUT" |
+            tr '[:lower:]' '[:upper:]' |
+            tr -d ':[:space:]'
+          )"
+
+          JKS_SHA256="$(
+            keytool \
+              -exportcert \
+              -rfc \
+              -keystore "$KEYSTORE_PATH" \
+              -storepass "$KEYSTORE_PASSWORD" \
+              -alias "$KEY_ALIAS" |
+            openssl x509 \
+              -noout \
+              -fingerprint \
+              -sha256 |
+            sed 's/^.*=//' |
+            tr '[:lower:]' '[:upper:]' |
+            tr -d ':[:space:]'
+          )"
+
+          if [ -z "$APK_SHA256" ]; then
+            echo "::error::無法從 apksigner 輸出取得 APK certificate SHA-256。"
+            cat "$APK_SIGNATURE_OUTPUT"
+            exit 1
+          fi
+
+          if [ -z "$JKS_SHA256" ]; then
+            echo "::error::無法取得 JKS certificate SHA-256。"
+            exit 1
+          fi
+
+          echo "APK certificate SHA-256: $APK_SHA256"
+          echo "JKS certificate SHA-256: $JKS_SHA256"
+
+          if [ "$APK_SHA256" != "$JKS_SHA256" ]; then
+            echo "::error::APK 並非由指定的 Android release keystore 簽署。"
+            echo "::error::APK certificate：$APK_SHA256"
+            echo "::error::JKS certificate：$JKS_SHA256"
+            exit 1
+          fi
+
+          {
+            echo "### Android APK signing"
+            echo
+            echo "- APK signature verification: passed"
+            echo "- Signing certificate SHA-256: \`$APK_SHA256\`"
+            echo "- Application version: \`${{ needs.prepare-version.outputs.app-version }}\`"
+            echo "- Android versionCode: \`${{ needs.prepare-version.outputs.build-number }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "APK 簽章及 signing certificate 驗證成功。"
 
       - name: Prepare Android release file
         shell: bash
@@ -157,6 +401,16 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           compression-level: 0
+
+      - name: Remove Android signing files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          rm -f \
+            "$GITHUB_WORKSPACE/android/android-release.jks" \
+            "$GITHUB_WORKSPACE/android/key.properties"
+
+          echo "Runner 上的 Android signing files 已刪除。"
 
   build-windows:
     name: Build Windows Installer

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ app.*.map.json
 .env
 
 .dart_tool/
+
+# apk release
+*.jks
+android/key.properties
+android/*.jks
+android/*.keystore
+*.base64

--- a/.zcode/plans/plan-sess_a20b3f9c-1410-4fc2-93fe-c349f79fe9ea.md
+++ b/.zcode/plans/plan-sess_a20b3f9c-1410-4fc2-93fe-c349f79fe9ea.md
@@ -1,0 +1,72 @@
+## Overview
+
+Add a **DEC/FRAC display toggle** next to the DEG/RAD chip. In **FRAC** mode, results are shown exactly as **simplified fractions / mixed numbers / surds** (e.g. `4/3 → 1⅓`, `√12 → 2√3`, `√2+√3`), rendered as rich math (TeX) like the expression area. In **DEC** mode, behavior is unchanged (decimals). The preference is persisted via `SharedPreferences`, following the existing `theme_settings.dart` pattern.
+
+**Key design decision — exact (symbolic) evaluation, not double-guessing.** The expression is already a *typed AST* (`NumberNode`, `FractionNode`, `RootNode`, `PowerNode`, …). I'll walk that AST with exact `BigInt` arithmetic to produce the simplified form directly. This guarantees correctness for the middle-school simplification rules. When an exact form is impossible (trig, `π`, `e`, `ln`, `log`, non-integer powers, `³√x`, huge radicands, rationalizing failures), the exact path gracefully *bails out → falls back to the existing decimal path*. Exactly the fallback the user asked for.
+
+No new dependencies (`BigInt` is built-in; `flutter_math_fork` already in use).
+
+## Core algorithm — exact algebra (new, under `lib/features/calculator/service/exact_math/`)
+
+1. **`rational.dart` — `Rational`**: a minimal exact-fraction type (`BigInt` numerator, `BigInt` denominator > 0, always reduced). Supports `+ - * /`, comparisons, `fromDecimalString` (parses `"2.5" → 5/2` exactly from the `NumberNode` string), and sign handling.
+
+2. **`exact_number.dart` — `ExactNumber`**: represents a sum of surd terms `Σ coeff_i · √radicand_i`, stored as a `Map<BigInt radicand, Rational coeff>` (radicand square-free; radicand `1` = rational part). Supports:
+   - **add/sub**: merge matching radicands.
+   - **mul**: distribute; product of `√r1·√r2` is resimplified to `√(squarefree)·k` and the `k` folded into the coefficient (so `√2·√8 = √16 = 4`).
+   - **div**: invert via rationalization; invertible for single-term or two-term (`a+b√d`) denominators; otherwise bail (return `null`).
+   - **integer power**: repeated multiplication.
+   - **sqrtOf(n)**: factor out the largest perfect square → `k·√squarefree`.
+   - `toApproximate` (double), `isZero`, and a **bail-out** convention (`null`).
+   - Square-free extraction by trial division up to √n, capped (radicand > 1e15 → bail to avoid slow factorization).
+
+3. **`exact_value_evaluator.dart`**: walks the typed AST (`SequenceNode`) into `ExactNumber?`, using the same operator-precedence table as `ExpressionCompiler` (`+/-` =1, `*/` ÷ =2, unary `-` =3). Node handling:
+   - `NumberNode` → `Rational.fromDecimalString(value)`; `ConstantNode.pi/e` → bail (transcendental); `ConstantNode.answer` → exact only if Ans is an integer, else bail.
+   - `FractionNode` → num ÷ den; `GroupNode` → recurse; `RootNode` square root → exact (rationalize perfect squares / surd); `RootNode` *n-th* (degree set) → bail.
+   - `PowerNode` → exact if exponent is an integer; non-integer exponent → bail. (`x^0.5` not specially handled → bail; users have the dedicated √ key for surds.)
+   - `FunctionNode` (sin/cos/tan/asin/acos/atan/log10/ln/abs) → bail (DEG/RAD irrelevant — they always bail).
+   - Any bail propagates as `null` (→ decimal fallback).
+
+4. **`exact_value_formatter.dart`**: `ExactNumber` → TeX string for `flutter_math_fork`:
+   - Rational-only result → integer (plain), proper/improper fraction `\frac{n}{d}`, or **mixed** `w\frac{n}{d}` when `|numerator| > denominator`.
+   - Surd terms: `2\sqrt{3}`, `\sqrt{2}` (coeff ±1 omitted), `-\frac{1}{2}\sqrt{3}`, combined as a signed sum with the rational part first, e.g. `1\frac{1}{2}-\frac{1}{2}\sqrt{3}`.
+   - Never emits TeX for trivial results (integers, 0) — those stay plain text.
+
+## Persistence + UI (mirrors `theme_settings.dart`)
+
+5. **`lib/app/result_format_settings.dart`** — `ResultFormatPreference { decimal, fraction }` with `.label` (`'DEC'`/`'FRAC'`), `.fromName`; `ResultFormatSettingsStorage` (key `'result_format_preference'`, `getString`/`setString`); `initialResultFormatPreferenceProvider`, `ResultFormatSettingsNotifier`, `resultFormatSettingsProvider`. Default `decimal` (preserves current behavior).
+
+6. **`lib/app/bootstrap.dart`** — pre-load `ResultFormatSettingsStorage.load()` and override `initialResultFormatPreferenceProvider` in `ProviderScope`.
+
+7. **`lib/features/calculator/view/widgets/result_format_indicator.dart`** — an `ActionChip` (clone of `mode_indicator.dart`, icon `Icons.calculate`), label = current mode's `.label`.
+
+8. **`lib/features/calculator/view/calculator_screen.dart`** — add `ResultFormatIndicator` to the AppBar actions immediately **after** the DEG/RAD chip; pass `formattedTex` into `ResultDisplay`.
+
+9. **`lib/features/calculator/view/widgets/result_display.dart`** — accept optional `String? tex`; when present, render via `Math.tex(tex, mathStyle: MathStyle.text)` inside a right-aligned, horizontally-scrollable container matching existing typography (`headlineMedium`, weight 600, `onSurface`/error colors); errors and plain results unchanged. Decimals are unaffected.
+
+## Engine + view-model wiring
+
+10. **`lib/features/calculator/model/calculation_result.dart`** — add optional `String? formattedTex` (default `null`). `formattedValue` stays the plain decimal (used for `Ans`/errors).
+
+11. **`lib/features/calculator/service/tree_calculator_engine.dart`** — `evaluate(...)` gains a `ResultFormatPreference resultFormat` param. In **fraction** mode it additionally runs `ExactValueEvaluator` → `ExactValueFormatter`; sets `formattedTex` to the TeX (or leaves `null` on bail-out → decimal shows). The numeric `value` is always the existing `double` (so `Ans` stays consistent across modes).
+
+12. **`lib/features/calculator/viewmodel/calculator_view_model.dart`**:
+    - `calculate()` reads `ref.read(resultFormatSettingsProvider)` and passes it to the engine.
+    - New `toggleResultFormat()` flips the persisted preference (via the notifier) **and**, if a result is currently shown (`state.result != null`), re-evaluates the current `document.root` with the new format so the display updates instantly without pressing `=`.
+
+## Tests
+- **`test/features/calculator/service/exact_math/*_test.dart`** — heavy unit tests on `Rational`, `ExactNumber` (add/mul/div/rationalize/sqrtOf, simplification √12→2√3, √2·√8→4, 1/√2→√2/2, bail-outs), `ExactValueEvaluator` (build trees from nodes; assert exact outputs and bail-outs), `ExactValueFormatter` (TeX strings incl. mixed `1\frac{1}{3}`, surds, signed sums).
+- **`test/app/result_format_settings_test.dart`** — mirrors `theme_settings_test.dart` (storage round-trip, notifier, override) using the existing `setupSharedPreferencesForTest` helper.
+- Extend **`tree_calculator_engine_test.dart`** — assert `formattedTex` in fraction mode for representative cases (fractions, surds, mixed) and `null` (bail-out) for trig.
+- Run `flutter analyze` + full test suite; the existing DEG/RAD and decimal tests must stay green (decimal is the default).
+
+## Behavior summary
+| Input | DEC mode (unchanged) | FRAC mode (new) |
+|---|---|---|
+| `4 / 3` | `1.33333333333` | `1⅓` (TeX) |
+| `√12` | `3.46410161514` | `2√3` (TeX) |
+| `1 / √2` | `0.707106781187` | `√2/2` (TeX) |
+| `√2 + √3` | `3.14626436994` | `√2 + √3` (TeX) |
+| `sin(30°)` | `0.5` | `0.5` (bail-out → decimal, since trig) |
+| `2 + 3` | `5` | `5` (plain — trivial) |
+
+Files touched: **6 new** (`result_format_settings.dart`, 4 exact-math files, `result_format_indicator.dart`) + **6 modified** (`calculation_result.dart`, `tree_calculator_engine.dart`, `calculator_view_model.dart`, `calculator_screen.dart`, `result_display.dart`, `bootstrap.dart`), plus tests. No new dependencies.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,11 +1,24 @@
+import java.io.FileInputStream
+import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+
+if (keystorePropertiesFile.exists()) {
+    FileInputStream(keystorePropertiesFile).use {
+        keystoreProperties.load(it)
+    }
+}
+
 plugins {
     id("com.android.application")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 
 android {
-    namespace = "com.example.scientific_calculator"
+    namespace = "com.swarfte.scientific_calculator"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -15,28 +28,71 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.scientific_calculator"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        applicationId = "com.swarfte.scientific_calculator"
+
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
+
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            if (!keystorePropertiesFile.exists()) {
+                throw GradleException(
+                    "找不到 android/key.properties，不能建立 signed release APK。"
+                )
+            }
+
+            keyAlias =
+                keystoreProperties.getProperty("keyAlias")
+                    ?: throw GradleException(
+                        "android/key.properties 缺少 keyAlias"
+                    )
+
+            keyPassword =
+                keystoreProperties.getProperty("keyPassword")
+                    ?: throw GradleException(
+                        "android/key.properties 缺少 keyPassword"
+                    )
+
+            storePassword =
+                keystoreProperties.getProperty("storePassword")
+                    ?: throw GradleException(
+                        "android/key.properties 缺少 storePassword"
+                    )
+
+            val storeFilePath =
+                keystoreProperties.getProperty("storeFile")
+                    ?: throw GradleException(
+                        "android/key.properties 缺少 storeFile"
+                    )
+
+            storeFile = file(storeFilePath)
+
+            if (storeFile == null || !storeFile!!.isFile) {
+                throw GradleException(
+                    "找不到 Android release keystore：${storeFile?.absolutePath}"
+                )
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }
 
+/*
+ * 取代已棄用的 android.kotlinOptions。
+ * 此區塊必須放在 android {} 外面。
+ */
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,4 @@ android.useAndroidX=true
 android.newDsl=false
 # This builtInKotlin flag was added by the Flutter template
 android.builtInKotlin=false
+org.gradle.kotlin.dsl.allWarningsAsErrors=false

--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -5,6 +5,7 @@ import 'package:window_manager/window_manager.dart';
 import '../core/platform/platform_info.dart';
 import 'app.dart';
 import 'always_on_top_settings.dart';
+import 'result_format_settings.dart';
 import 'theme_settings.dart';
 import 'windows_state.dart';
 
@@ -63,6 +64,9 @@ Future<void> bootstrap() async {
   // 預先載入主題偏好，讓第一個畫面就套用上次選擇的主題，避免啟動閃爍。
   final initialThemePreference = await ThemeSettingsStorage.load();
 
+  // 預先載入結果顯示格式偏好（DEC/FRAC），讓首次計算就套用正確格式。
+  final initialResultFormat = await ResultFormatSettingsStorage.load();
+
   runApp(
     ProviderScope(
       overrides: [
@@ -70,6 +74,9 @@ Future<void> bootstrap() async {
           (ref) => initialThemePreference,
         ),
         initialAlwaysOnTopProvider.overrideWith((ref) => initialAlwaysOnTop),
+        initialResultFormatPreferenceProvider.overrideWith(
+          (ref) => initialResultFormat,
+        ),
       ],
       child: WindowStateObserver(child: ScientificCalculatorApp()),
     ),

--- a/lib/app/result_format_settings.dart
+++ b/lib/app/result_format_settings.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 結果顯示格式偏好：小數或分數／根式。
+///
+/// 配合 DEG/RAD 旁的切換鈕使用。`decimal` 為預設值（保留原有行為）；
+/// `fraction` 時會在可精確化的情況下以最簡分數／帶分數／根式顯示結果，否則
+/// （三角、π、e、log 等）回退為小數。
+enum ResultFormatPreference {
+  /// 小數（預設）。
+  decimal,
+
+  /// 分數／根式（盡量精確化簡，無法時回退小數）。
+  fraction;
+
+  String get label {
+    return switch (this) {
+      ResultFormatPreference.decimal => 'DEC',
+      ResultFormatPreference.fraction => 'FRAC',
+    };
+  }
+
+  /// 只接受已知的持久化字串；未知值或 `null` 一律回傳 [decimal]。
+  static ResultFormatPreference fromName(String? name) {
+    return switch (name) {
+      'fraction' => ResultFormatPreference.fraction,
+      _ => ResultFormatPreference.decimal,
+    };
+  }
+}
+
+/// 以 SharedPreferences 持久化儲存結果顯示格式偏好。
+///
+/// 沿用 [ThemeSettingsStorage] 的 `SharedPreferencesAsync` 模式。
+class ResultFormatSettingsStorage {
+  static const _key = 'result_format_preference';
+  static final SharedPreferencesAsync _preferences = SharedPreferencesAsync();
+
+  /// 載入已儲存的偏好；未儲存時回傳 [ResultFormatPreference.decimal]。
+  static Future<ResultFormatPreference> load() async {
+    final name = await _preferences.getString(_key);
+    return ResultFormatPreference.fromName(name);
+  }
+
+  static Future<void> save(ResultFormatPreference preference) {
+    return _preferences.setString(_key, preference.name);
+  }
+}
+
+/// 初始結果格式偏好。
+///
+/// 在 `bootstrap()` 中以從 SharedPreferences 載入的值覆寫，讓第一個畫面就
+/// 套用正確的格式，避免啟動時的不一致。
+final initialResultFormatPreferenceProvider = Provider<ResultFormatPreference>(
+  (ref) => ResultFormatPreference.decimal,
+);
+
+/// 結果格式偏好狀態。
+///
+/// 讀取 [initialResultFormatPreferenceProvider] 作為初始值；[set] 同步更新
+/// state，再非同步寫入 [ResultFormatSettingsStorage]。
+class ResultFormatSettingsNotifier extends Notifier<ResultFormatPreference> {
+  @override
+  ResultFormatPreference build() =>
+      ref.read(initialResultFormatPreferenceProvider);
+
+  Future<void> set(ResultFormatPreference value) async {
+    if (state == value) {
+      return;
+    }
+    state = value;
+    await ResultFormatSettingsStorage.save(value);
+  }
+}
+
+final resultFormatSettingsProvider =
+    NotifierProvider<ResultFormatSettingsNotifier, ResultFormatPreference>(
+      ResultFormatSettingsNotifier.new,
+    );

--- a/lib/features/calculator/model/calculation_result.dart
+++ b/lib/features/calculator/model/calculation_result.dart
@@ -1,6 +1,19 @@
 class CalculationResult {
-  const CalculationResult({required this.value, required this.formattedValue});
+  const CalculationResult({
+    required this.value,
+    required this.formattedValue,
+    this.formattedTex,
+  });
 
   final num value;
+
+  /// 顯示用的純文字值（小數格式）；供 `ResultDisplay` 在沒有 [formattedTex]
+  /// 時顯示，也作為 `Ans` 等以純文字傳遞時的來源。
   final String formattedValue;
+
+  /// 以 TeX 表示的精確結果（最簡分數／帶分數／根式）。
+  ///
+  /// 僅在「分數」顯示模式且結果可精確化簡時為非 `null`。為 `null` 時
+  /// [ResultDisplay] 退回使用 [formattedValue]（小數）。
+  final String? formattedTex;
 }

--- a/lib/features/calculator/service/exact_math/exact_number.dart
+++ b/lib/features/calculator/service/exact_math/exact_number.dart
@@ -1,0 +1,398 @@
+import 'dart:math' as math;
+
+import 'rational.dart';
+
+/// 根式和的表示：`c₀ + c₁·√r₁ + c₂·√r₂ + …`，其中 `rᵢ` 為大於 1 的
+/// square-free 整數，`cᵢ` 為 [Rational] 係數。`r = 1` 代表純有理部份。
+///
+/// 此型別可精確表示中學常見的「化簡」結果，例如：
+/// - `2 + 1/3` -> `{1: 7/3}`
+/// - `√12` -> `{3: 2}`（即 `2√3`）
+/// - `√2 + √3` -> `{2: 1, 3: 1}`
+/// - `(1/2)√3` -> `{3: 1/2}`
+///
+/// 所有運算皆以 [BigInt] 精確進行。無法以根式精確表示時（例如有理化分母
+/// 失敗、n 次根、巨大被開方數），呼叫端會回退到小數路徑。
+class ExactNumber {
+  ExactNumber._(this._terms);
+
+  /// 內部儲存：radicand -> coefficient。不變量：
+  /// - 所有 radicand 為 square-free（radicand 1 代表有理部份）。
+  /// - 係數為 0 的項會被移除。
+  /// - radicand 恆 > 0（負被開方數無實根號表示）。
+  final Map<BigInt, Rational> _terms;
+
+  /// 空的根式和（即 0）。
+  static final ExactNumber zero = ExactNumber._(const {});
+
+  /// 由 [terms] 建構；會去除 0 係數項。呼叫者需保證 radicand 為 square-free。
+  factory ExactNumber.fromTerms(Map<BigInt, Rational> terms) {
+    final cleaned = <BigInt, Rational>{};
+    for (final entry in terms.entries) {
+      if (!entry.value.isZero) {
+        cleaned[entry.key] = entry.value;
+      }
+    }
+    return ExactNumber._(cleaned);
+  }
+
+  /// 由 [Rational] 建立純有理數。
+  factory ExactNumber.rational(Rational value) => ExactNumber.fromTerms({
+    BigInt.one: value,
+  });
+
+  /// 由 [int] 建立純整數。
+  factory ExactNumber.fromInt(int value) =>
+      ExactNumber.rational(Rational.fromInt(value));
+
+  /// 是否為 0。
+  bool get isZero => _terms.isEmpty;
+
+  /// 是否為純有理數（沒有根號項）。
+  ///
+  /// 空的 terms（即 0）或僅含 radicand 1 的項皆視為純有理。
+  bool get isRational {
+    if (_terms.isEmpty) return true;
+    if (_terms.length == 1 && _terms.containsKey(BigInt.one)) return true;
+    return false;
+  }
+
+  /// 取得有理部份（radicand 1 的係數），不存在則為 0。
+  Rational get rationalPart => _terms[BigInt.one] ?? Rational.zero;
+
+  /// 取得所有根號項（不含 radicand 1），依 radicand 遞增排序。
+  ///
+  /// 回傳不可變的 list of (radicand, coefficient)。
+  List<MapEntry<BigInt, Rational>> get surdTerms {
+    final result = _terms.entries
+        .where((e) => e.key != BigInt.one)
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    return List.unmodifiable(result);
+  }
+
+  /// 是否為負（依近似值判斷）。
+  bool get isNegative => toDouble().isNegative;
+
+  /// 轉成 [double] 近似值。
+  double toDouble() {
+    var sum = 0.0;
+    _terms.forEach((radicand, coeff) {
+      if (radicand == BigInt.one) {
+        sum += coeff.toDouble();
+      } else {
+        sum += coeff.toDouble() * _sqrtDouble(radicand);
+      }
+    });
+    return sum;
+  }
+
+  // ---- 算術 --------------------------------------------------------------
+
+  ExactNumber operator +(ExactNumber other) {
+    final result = Map<BigInt, Rational>.from(_terms);
+    for (final entry in other._terms.entries) {
+      final existing = result[entry.key] ?? Rational.zero;
+      final combined = existing + entry.value;
+      if (combined.isZero) {
+        result.remove(entry.key);
+      } else {
+        result[entry.key] = combined;
+      }
+    }
+    return ExactNumber._(result);
+  }
+
+  ExactNumber operator -(ExactNumber other) => this + (-other);
+
+  /// 取負號。
+  ExactNumber operator -() {
+    final result = _terms.map((key, value) => MapEntry(key, -value));
+    return ExactNumber._(result);
+  }
+
+  /// 乘法。distribute 後將 `√(r1·r2)` 重新化簡為 square-free。
+  ExactNumber operator *(ExactNumber other) {
+    final result = <BigInt, Rational>{};
+    void add(BigInt radicand, Rational coeff) {
+      final existing = result[radicand] ?? Rational.zero;
+      final combined = existing + coeff;
+      if (combined.isZero) {
+        result.remove(radicand);
+      } else {
+        result[radicand] = combined;
+      }
+    }
+
+    for (final a in _terms.entries) {
+      for (final b in other._terms.entries) {
+        final productRadicand = a.key * b.key;
+        final productCoeff = a.value * b.value;
+        final simplified = _simplifyRadicalProduct(productRadicand);
+        add(simplified.radicand, productCoeff * simplified.coefficient);
+      }
+    }
+    return ExactNumber._(result);
+  }
+
+  /// 整數次方（反覆乘法）。`n >= 0`。
+  ExactNumber pow(int n) {
+    if (n < 0) {
+      throw ArgumentError('ExactNumber.pow requires n >= 0');
+    }
+    var result = ExactNumber.fromInt(1);
+    var base = this;
+    var exp = n;
+    while (exp > 0) {
+      if (exp & 1 == 1) {
+        result = result * base;
+      }
+      exp >>= 1;
+      if (exp > 0) {
+        base = base * base;
+      }
+    }
+    return result;
+  }
+
+  /// 除法。有理化分母；可處理單項分母與兩項分母 `a + b√d`。
+  /// 無法有理化時回傳 `null`（呼叫端 fallback 到小數）。
+  ExactNumber? divide(ExactNumber other) {
+    if (other.isZero) {
+      return null; // 除以 0；交由 decimal 路徑拋 overflow/domain。
+    }
+    if (other.surdTerms.isEmpty) {
+      // 純有理分母：直接逐項除。
+      final divisor = other.rationalPart;
+      final result = _terms.map(
+        (key, value) => MapEntry(key, value / divisor),
+      );
+      return ExactNumber._(result);
+    }
+    if (other.surdTerms.length == 1 && other.rationalPart.isZero) {
+      // 單一根號項 `c√d`：分子分母同乘 `√d`，得 `√d/d`。
+      final surd = other.surdTerms.single;
+      final d = surd.key;
+      final coeff = surd.value;
+      // new denominator = c√d · √d = c·d（有理）。
+      final newRationalDenom = coeff * Rational.integer(d);
+      // new numerator = this · √d。
+      final sqrtD = ExactNumber._({d: Rational.integer(BigInt.one)});
+      final newNumerator = this * sqrtD;
+      final result = newNumerator._terms.map(
+        (key, value) => MapEntry(key, value / newRationalDenom),
+      );
+      return ExactNumber._(result);
+    }
+    if (other.surdTerms.length == 1) {
+      // 兩項分母 `a + b√d`：乘以共軛 `a - b√d`，分母 = `a² - b²d`。
+      final d = other.surdTerms.single.key;
+      final a = other.rationalPart;
+      final b = other.surdTerms.single.value;
+      final conjugateTerms = <BigInt, Rational>{
+        BigInt.one: a,
+        d: -b,
+      };
+      final conjugate = ExactNumber._(conjugateTerms);
+      final denomRational = a * a - b * b * Rational.integer(d);
+      if (denomRational.isZero) {
+        return null;
+      }
+      final newNumerator = this * conjugate;
+      final result = newNumerator._terms.map(
+        (key, value) => MapEntry(key, value / denomRational),
+      );
+      return ExactNumber._(result);
+    }
+    // 三項以上根號項（如 a + b√2 + c√3）：無法簡單有理化，fallback。
+    return null;
+  }
+
+  /// 取倒數（`1 / this`）。等價於 `ExactNumber.fromInt(1).divide(this)`。
+  ExactNumber? reciprocal() => ExactNumber.fromInt(1).divide(this);
+
+  @override
+  bool operator ==(Object other) {
+    return other is ExactNumber && _mapsEqual(_terms, other._terms);
+  }
+
+  static bool _mapsEqual(Map<BigInt, Rational> a, Map<BigInt, Rational> b) {
+    if (a.length != b.length) return false;
+    for (final key in a.keys) {
+      if (a[key] != b[key]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAllUnordered(
+    _terms.entries.map((e) => Object.hash(e.key, e.value)),
+  );
+
+  @override
+  String toString() {
+    if (isZero) return '0';
+    return _terms.entries.map((e) {
+      if (e.key == BigInt.one) return '${e.value}';
+      return '${e.value}√${e.key}';
+    }).join(' + ');
+  }
+}
+
+// ---- free helpers -------------------------------------------------------
+
+/// `_RadicalProduct { radicand (square-free), coefficient }`：`√n` 化簡結果。
+class _RadicalProduct {
+  const _RadicalProduct(this.radicand, this.coefficient);
+  final BigInt radicand;
+  final Rational coefficient;
+}
+
+/// 將乘積 radicand `n = r1*r2` 化簡成 square-free radicand 與提出來的整數係數。
+///
+/// 例如 `n = 12 = 4·3` -> `radicand = 3, coefficient = 2`。
+/// `n = 1` -> `(1, 1)`。`n` 為 0 視為 0。
+_RadicalProduct _simplifyRadicalProduct(BigInt n) {
+  if (n == BigInt.zero) {
+    return _RadicalProduct(BigInt.one, Rational.zero);
+  }
+  if (n == BigInt.one) {
+    return _RadicalProduct(BigInt.one, Rational.integer(BigInt.one));
+  }
+  final extracted = _extractSquareFactor(n);
+  if (extracted.squareFree == BigInt.one) {
+    // n 是完全平方 -> 純整數。
+    return _RadicalProduct(
+      BigInt.one,
+      Rational.integer(extracted.coefficient),
+    );
+  }
+  return _RadicalProduct(
+    extracted.squareFree,
+    Rational.integer(extracted.coefficient),
+  );
+}
+
+class _SquareExtraction {
+  const _SquareExtraction(this.coefficient, this.squareFree);
+  final BigInt coefficient; // 提出 radicand 外的整數（>= 1）
+  final BigInt squareFree; // 剩餘 square-free 部份（>= 1）
+}
+
+/// 對 `n` 提出最大的完全平方因數 `k²`，回傳 `(k, n / k²)`。
+///
+/// 對 [n] 做質因數試除：每個質數 p 計算其指數，偶數部份提出作為 p^(e/2)，
+/// 奇數部份留在 squareFree 中。為避免對巨大 n 時的緩慢試除，對 `n > 1e15`
+/// 直接回傳 `(1, n)`（呼叫端會 fallback 到小數）。
+_SquareExtraction _extractSquareFactor(BigInt n) {
+  if (n <= BigInt.one) {
+    return _SquareExtraction(BigInt.one, n);
+  }
+  // 超過此上限不嘗試因式分解（避免卡頓）；呼叫端會 fallback 到小數。
+  const maxTrial = 1000000000000000; // 1e15
+  if (n > BigInt.from(maxTrial)) {
+    return _SquareExtraction(BigInt.one, n);
+  }
+
+  var remaining = n;
+  var coefficient = BigInt.one;
+  var squareFree = BigInt.one;
+
+  // 處理 2。
+  if (remaining % BigInt.two == BigInt.zero) {
+    var exp = 0;
+    while (remaining % BigInt.two == BigInt.zero) {
+      remaining ~/= BigInt.two;
+      exp++;
+    }
+    coefficient *= bigIntPow(BigInt.two, exp ~/ 2);
+    if (exp & 1 == 1) {
+      squareFree *= BigInt.two;
+    }
+  }
+
+  // 奇質數試除。
+  var p = BigInt.from(3);
+  while (p * p <= remaining) {
+    if (remaining % p == BigInt.zero) {
+      var exp = 0;
+      while (remaining % p == BigInt.zero) {
+        remaining ~/= p;
+        exp++;
+      }
+      coefficient *= bigIntPow(p, exp ~/ 2);
+      if (exp & 1 == 1) {
+        squareFree *= p;
+      }
+    }
+    p += BigInt.two;
+  }
+  // 剩下的 remaining 是大於 1 的質數（指數 1）。
+  if (remaining > BigInt.one) {
+    squareFree *= remaining;
+  }
+  return _SquareExtraction(coefficient, squareFree);
+}
+
+/// 對 [radicand] 取平方根，回傳 [ExactNumber]（可能為純有理或根式）。
+///
+/// - radicand < 0：回傳 `null`（實數範圍無定義）。
+/// - radicand == 0：回傳 0。
+/// - radicand == 1：回傳 1。
+/// - 否則提出完全平方因數：`√12 = 2√3`。
+///
+/// 超過 `_extractSquareFactor` 上限的 radicand 會回傳未化簡的根號項
+/// （仍可顯示，只是未化到最簡）；呼叫端可選擇 fallback。
+ExactNumber? sqrtOf(BigInt radicand) {
+  if (radicand.isNegative) {
+    return null;
+  }
+  if (radicand == BigInt.zero) {
+    return ExactNumber.zero;
+  }
+  final extracted = _extractSquareFactor(radicand);
+  if (extracted.squareFree == BigInt.one) {
+    return ExactNumber.rational(Rational.integer(extracted.coefficient));
+  }
+  return ExactNumber._({
+    extracted.squareFree: Rational.integer(extracted.coefficient),
+  });
+}
+
+/// 對一個 [Rational] 取平方根。僅當分子分母皆為完全平方或可提出 square
+/// factor 時回傳精確 [ExactNumber]，否則回傳 `null`。
+///
+/// 例如 `sqrt(1/4) = 1/2`、`sqrt(12/1) = 2√3`、`sqrt(2/3) = √6/3`。
+ExactNumber? sqrtOfRational(Rational value) {
+  if (value.isNegative) {
+    return null;
+  }
+  if (value.isZero) {
+    return ExactNumber.zero;
+  }
+  final numSqrt = sqrtOf(value.numerator.abs());
+  final denSqrt = sqrtOf(value.denominator);
+  if (numSqrt == null || denSqrt == null) {
+    return null;
+  }
+  // sqrt(num)/sqrt(den)，若有理化分母。
+  final divided = numSqrt.divide(denSqrt);
+  return divided;
+}
+
+/// 以 [double] 計算 [n] 的平方根（內部近似用，不外露）。
+double _sqrtDouble(BigInt n) {
+  // 對大整數先取近似 double 再開根，避免溢位。
+  return _bigSqrtToDouble(n);
+}
+
+double _bigSqrtToDouble(BigInt n) {
+  if (n < BigInt.from(1 << 52)) {
+    return math.sqrt(n.toDouble());
+  }
+  // 對極大數，以位數縮減：先算整數平方根估計，再修正為 double。
+  final approx = bigIntSqrt(n);
+  final hi = (approx + BigInt.one).toDouble();
+  final lo = approx.toDouble();
+  return (math.sqrt(hi) + math.sqrt(lo)) / 2;
+}

--- a/lib/features/calculator/service/exact_math/exact_value_evaluator.dart
+++ b/lib/features/calculator/service/exact_math/exact_value_evaluator.dart
@@ -1,0 +1,244 @@
+import '../../model/expression/expression_node.dart';
+import '../../model/expression/node/constant_node.dart';
+import '../../model/expression/node/fraction_node.dart';
+import '../../model/expression/node/function_node.dart';
+import '../../model/expression/node/group_node.dart';
+import '../../model/expression/node/number_node.dart';
+import '../../model/expression/node/operator_node.dart';
+import '../../model/expression/node/power_node.dart';
+import '../../model/expression/node/root_node.dart';
+import '../../model/expression/node/sequence_node.dart';
+import 'exact_number.dart';
+import 'rational.dart';
+
+/// 以 [ExactNumber]（根式和）精確求值 Expression Tree。
+///
+/// 與 [ExpressionCompiler]（Pratt parser）使用相同的優先順序與結構，差別在於
+/// 算術改為 [ExactNumber]（[BigInt] 有理數 + 根式）。任何無法精確表示的節點
+/// （三角／指對數函數、π、e、n 次根、非整數次方、負數開根號…）會回傳 `null`，
+/// 由呼叫端 fallback 到 decimal 路徑。
+///
+/// `answer`（`Ans` 常數）僅在它本身為整數時可精確參與；否則回傳 `null`。
+class ExactValueEvaluator {
+  const ExactValueEvaluator({this.answer});
+
+  /// 上一個答案，供 [MathConstant.answer] 使用；`null` 表示無答案。
+  final double? answer;
+
+  /// 求值 [root]。回傳 `null` 表示無法精確表示。
+  ExactNumber? evaluate(SequenceNode root) {
+    final parser = _ExactParser(this);
+    return parser.parseSequence(root);
+  }
+}
+
+/// 以 Sequence children 為 token stream 的 Pratt parser（exact 版本）。
+///
+/// 優先順序與 [ExpressionCompiler] 的 `_PrattParser` 一致：
+/// - `+` / `-`（二元）：1
+/// - `*` / `/`：2
+/// - unary `-`：3
+class _ExactParser {
+  _ExactParser(this.evaluator);
+
+  final ExactValueEvaluator evaluator;
+  int _position = 0;
+
+  ExactNumber? parseSequence(SequenceNode sequence) {
+    final savedPosition = _position;
+    _position = 0;
+    final children = sequence.children;
+    if (children.isEmpty) {
+      // 空 sequence 視為 0（與 decimal 路徑一致：Validator 會攔截大部分空結構）。
+      _position = savedPosition;
+      return ExactNumber.zero;
+    }
+    final result = _parseExpression(children);
+    final consumedAll = _position == children.length;
+    _position = savedPosition;
+    // 若解析未耗盡所有 children（結構異常），視為無法求值；交由 decimal 處理。
+    if (result == null || !consumedAll) {
+      return null;
+    }
+    return result;
+  }
+
+  ExactNumber? _parseExpression(List<ExpressionNode> children) =>
+      _parseBinary(children, 0);
+
+  ExactNumber? _parseBinary(List<ExpressionNode> children, int minPrecedence) {
+    final initial = _parseUnary(children);
+    if (initial == null) return null;
+    var left = initial;
+
+    while (_position < children.length) {
+      final node = children[_position];
+      if (node is! OperatorNode) break;
+      final precedence = _binaryPrecedence(node.operator);
+      if (precedence < minPrecedence) break;
+      _position++;
+      final right = _parseBinary(children, precedence + 1);
+      if (right == null) return null;
+      final combined = _combine(node.operator, left, right);
+      if (combined == null) return null;
+      left = combined;
+    }
+    return left;
+  }
+
+  ExactNumber? _parseUnary(List<ExpressionNode> children) {
+    if (_position < children.length) {
+      final node = children[_position];
+      if (node is OperatorNode &&
+          node.operator == ExpressionOperator.subtract) {
+        _position++;
+        final operand = _parseUnary(children);
+        if (operand == null) return null;
+        return -operand;
+      }
+    }
+    return _parsePrimary(children);
+  }
+
+  ExactNumber? _parsePrimary(List<ExpressionNode> children) {
+    if (_position >= children.length) return null;
+    final node = children[_position];
+    _position++;
+    return _compileNode(node);
+  }
+
+  ExactNumber? _combine(
+    ExpressionOperator operator,
+    ExactNumber left,
+    ExactNumber right,
+  ) {
+    switch (operator) {
+      case ExpressionOperator.add:
+        return left + right;
+      case ExpressionOperator.subtract:
+        return left - right;
+      case ExpressionOperator.multiply:
+        return left * right;
+      case ExpressionOperator.divide:
+        return left.divide(right);
+    }
+  }
+
+  int _binaryPrecedence(ExpressionOperator operator) {
+    switch (operator) {
+      case ExpressionOperator.add:
+      case ExpressionOperator.subtract:
+        return 1;
+      case ExpressionOperator.multiply:
+      case ExpressionOperator.divide:
+        return 2;
+    }
+  }
+
+  ExactNumber? _compileNode(ExpressionNode node) {
+    switch (node) {
+      case NumberNode():
+        return _compileNumber(node);
+      case ConstantNode():
+        return _compileConstant(node);
+      case OperatorNode():
+        // primary 不應出現 operator；視為無法求值。
+        return null;
+      case FunctionNode():
+        // 所有函數（三角、log、ln、abs）皆非代數精確可表示。
+        return null;
+      case FractionNode():
+        final numerator = parseSequence(node.numerator);
+        final denominator = parseSequence(node.denominator);
+        if (numerator == null || denominator == null) return null;
+        return numerator.divide(denominator); // divide 回傳 null 時自動傳播。
+      case RootNode():
+        return _compileRoot(node);
+      case PowerNode():
+        return _compilePower(node);
+      case GroupNode():
+        return parseSequence(node.content);
+      case SequenceNode():
+        return parseSequence(node);
+      default:
+        return null;
+    }
+  }
+
+  ExactNumber? _compileNumber(NumberNode node) {
+    if (!node.isComplete) return null;
+    try {
+      final rational = Rational.fromDecimalString(node.value);
+      return ExactNumber.rational(rational);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  ExactNumber? _compileConstant(ConstantNode node) {
+    switch (node.constant) {
+      case MathConstant.pi:
+      case MathConstant.e:
+        // 超越常數無法以根式精確表示。
+        return null;
+      case MathConstant.answer:
+        // Ans 僅在整數時可精確參與。
+        final value = evaluator.answer;
+        if (value == null) return null;
+        if (value == value.roundToDouble()) {
+          return ExactNumber.fromInt(value.round());
+        }
+        return null;
+    }
+  }
+
+  ExactNumber? _compileRoot(RootNode node) {
+    // n 次根（degree 已設定）目前不支援精確表示，fallback。
+    if (node.degree != null) {
+      return null;
+    }
+    final radicand = parseSequence(node.radicand);
+    if (radicand == null) return null;
+    return _sqrt(radicand);
+  }
+
+  /// 對一個 [ExactNumber] 取平方根。
+  ///
+  /// 僅在 radicand 為純有理數時有意義：`√(a + b√c)` 一般無法化簡，回傳 `null`。
+  ExactNumber? _sqrt(ExactNumber value) {
+    if (!value.isRational) {
+      return null;
+    }
+    return sqrtOfRational(value.rationalPart);
+  }
+
+  ExactNumber? _compilePower(PowerNode node) {
+    final base = parseSequence(node.base);
+    final exponent = parseSequence(node.exponent);
+    if (base == null || exponent == null) return null;
+    if (!exponent.isRational) return null;
+    final expRational = exponent.rationalPart;
+    if (!expRational.isInteger) {
+      // 非整數次方（含 x^(1/2)）目前不嘗試代數化簡；使用者可用 √ 鍵。
+      return null;
+    }
+    final n = expRational.truncateToBigInt();
+    if (n >= BigInt.zero) {
+      final ni = n.toInt();
+      if (ni < 0 || BigInt.from(ni) != n) {
+        // 超過 int 範圍的指數，fallback。
+        return null;
+      }
+      return base.pow(ni);
+    }
+    // 負整數次方：先取倒數再取次方。
+    if (n == BigInt.from(-1)) {
+      return base.reciprocal();
+    }
+    final absExp = (-n).toInt();
+    if (absExp < 0 || BigInt.from(absExp) != -n) return null;
+    final reciprocal = base.reciprocal();
+    if (reciprocal == null) return null;
+    return reciprocal.pow(absExp);
+  }
+}

--- a/lib/features/calculator/service/exact_math/exact_value_formatter.dart
+++ b/lib/features/calculator/service/exact_math/exact_value_formatter.dart
@@ -1,0 +1,116 @@
+import 'exact_number.dart';
+import 'rational.dart';
+
+/// 將 [ExactNumber] 轉成 `flutter_math_fork` 可渲染的 TeX 字串。
+///
+/// 規則（符合中學化作業要求）：
+/// - 純整數結果 -> 回傳 `null`（讓 UI 顯示純文字，避免不必要的 TeX）。
+/// - 純分數（分子絕對值 < 分母）-> `\frac{n}{d}`。
+/// - 帶分數 -> `w\frac{n}{d}`（整數部份 + 真分數，正負號跟隨整數部份）。
+/// - 根號項 -> `c\sqrt{r}`，`c` 為 1 時省略係數、為 -1 時只留負號；
+///   `c` 為分數時寫成 `\frac{n}{d}\sqrt{r}`。
+/// - 多項組合：有理部份在前，根號項以 `+` / `-` 串接。
+///
+/// 任何情況下若結果會退化為純整數（如 `2 + 0√3`），回傳 `null`。
+class ExactValueFormatter {
+  const ExactValueFormatter();
+
+  /// 將 [value] 格式化為 TeX；若適合以純文字顯示則回傳 `null`。
+  String? format(ExactNumber value) {
+    if (value.isZero) {
+      return null; // 0 以純文字顯示。
+    }
+
+    final surds = value.surdTerms;
+    final rational = value.rationalPart;
+
+    // 純有理數：整數 -> null（純文字）；分數/帶分數 -> TeX。
+    if (surds.isEmpty) {
+      return _pureRationalToTex(rational);
+    }
+
+    // 有理部份 + 根號項：整數部份此時必須顯示（例如 1 + √2）。
+    final parts = <String>[];
+    if (!rational.isZero) {
+      parts.add(_rationalPartToTex(rational));
+    }
+
+    for (final surd in surds) {
+      final term = _surdToTex(surd.key, surd.value, isFirst: parts.isEmpty);
+      if (term != null) {
+        parts.add(term);
+      }
+    }
+
+    if (parts.isEmpty) {
+      return null;
+    }
+    return parts.join();
+  }
+
+  /// 純有理結果的 TeX。整數回傳 `null`（由純文字顯示）；否則分數／帶分數。
+  String? _pureRationalToTex(Rational rational) {
+    if (rational.isInteger) {
+      return null;
+    }
+    return _fractionBody(rational);
+  }
+
+  /// 在「有理 + 根號」組合中的有理部份 TeX。整數部份以純數字呈現（不省略），
+  /// 分數／帶分數則以 `\frac` / `w\frac` 呈現。
+  String _rationalPartToTex(Rational rational) {
+    if (rational.isInteger) {
+      return '${rational.numerator}';
+    }
+    return _fractionBody(rational);
+  }
+
+  /// 共用的分數／帶分數 TeX 主體（不含正負號判斷，由 [_fractionBody] 處理）。
+  String _fractionBody(Rational rational) {
+    final isNegative = rational.isNegative;
+    final absRational = rational.abs();
+    final absTruncated = absRational.truncateToBigInt();
+    final frac = absRational.fractionalPartAbs();
+
+    if (absTruncated == BigInt.zero) {
+      // 真分數（|n| < d），例如 1/3、-1/3。
+      final numerator = isNegative ? -frac.numerator : frac.numerator;
+      return '\\frac{$numerator}{${frac.denominator}}';
+    }
+    // 帶分數：w + n/d，整數部份帶正負號。
+    final signedWhole = isNegative ? -absTruncated : absTruncated;
+    return '$signedWhole\\frac{${frac.numerator}}{${frac.denominator}}';
+  }
+
+  /// 將單一根號項 `coeff · √radicand` 轉成 TeX，含與前一項的銜接符號。
+  ///
+  /// [isFirst] 為 `true` 時，第一個項若是負數須前置負號。
+  String? _surdToTex(BigInt radicand, Rational coeff, {required bool isFirst}) {
+    final isNegative = coeff.isNegative;
+    final absCoeff = coeff.abs();
+    final sign = isNegative ? '-' : '+';
+
+    final coefficientTex = _coefficientTex(absCoeff);
+    final body = '$coefficientTex\\sqrt{$radicand}';
+
+    if (isFirst) {
+      // 首項：正號省略，負號保留。
+      return isNegative ? '-$body' : body;
+    }
+    return ' $sign $body';
+  }
+
+  /// 係數部份的 TeX：
+  /// - 1 -> 空字串（`\sqrt{3}` 而非 `1\sqrt{3}`）
+  /// - 整數 -> 純數字
+  /// - 分數 -> `\frac{n}{d}`
+  String _coefficientTex(Rational coeff) {
+    if (coeff == Rational.one) {
+      return '';
+    }
+    if (coeff.isInteger) {
+      return '${coeff.numerator}';
+    }
+    return '\\frac{${coeff.numerator}}{${coeff.denominator}}';
+  }
+}

--- a/lib/features/calculator/service/exact_math/rational.dart
+++ b/lib/features/calculator/service/exact_math/rational.dart
@@ -1,0 +1,260 @@
+import 'dart:math' as math;
+
+/// 精確分數：以 [BigInt] 表示的分子／分母，永遠化為最簡且分母為正。
+///
+/// 這個型別是 exact（symbolic）計算路徑的基礎，用來產生「中學生作業」要求的
+/// 最簡分數／帶分數／根式結果。所有算術都在整數範圍內進行，不會累積浮點誤差。
+///
+/// 不變量（由工廠與 operators 共同維護）：
+/// - [denominator] > 0
+/// - gcd(|[numerator]|, [denominator]) == 1，或 [numerator] == 0 時
+///   [denominator] == 1。
+class Rational implements Comparable<Rational> {
+  Rational(this.numerator, this.denominator) {
+    if (denominator == BigInt.zero) {
+      throw const FormatException('Rational denominator cannot be zero.');
+    }
+  }
+
+  /// 由已經最簡的成員直接構造（不再次化簡）。內部使用。
+  const Rational._raw(this.numerator, this.denominator);
+
+  /// 整數。
+  Rational.integer(BigInt value) : this._raw(value, BigInt.one);
+
+  static final Rational zero = Rational.integer(BigInt.zero);
+  static final Rational one = Rational.integer(BigInt.one);
+
+  final BigInt numerator;
+  final BigInt denominator;
+
+  /// 是否為 0。
+  bool get isZero => numerator == BigInt.zero;
+
+  /// 是否為整數（分母為 1）。
+  bool get isInteger => denominator == BigInt.one;
+
+  /// 正負號：-1 / 0 / 1。
+  int get sign => numerator.sign;
+
+  /// 轉成 [double] 近似值（僅用於 fallback 顯示或比較）。
+  double toDouble() => numerator.toDouble() / denominator.toDouble();
+
+  /// 化為最簡並保證分母為正。
+  factory Rational.reduce(BigInt numerator, BigInt denominator) {
+    if (denominator == BigInt.zero) {
+      throw const FormatException('Rational denominator cannot be zero.');
+    }
+    if (numerator == BigInt.zero) {
+      return Rational._raw(BigInt.zero, BigInt.one);
+    }
+    var n = numerator;
+    var d = denominator;
+    if (d.isNegative) {
+      n = -n;
+      d = -d;
+    }
+    final divisor = n.abs().gcd(d);
+    if (divisor != BigInt.one) {
+      n = n ~/ divisor;
+      d = d ~/ divisor;
+    }
+    return Rational._raw(n, d);
+  }
+
+  /// 由 [int] 建立。
+  factory Rational.fromInt(int value) =>
+      Rational._raw(BigInt.from(value), BigInt.one);
+
+  /// 解析十進位字串（如 `"2"`、`"3.14"`、`"0.5"`、`"-1.25"`）為精確分數。
+  ///
+  /// 不處理科學記號（`1e3`）——`NumberNode` 來自使用者逐位輸入，不會出現。
+  /// 無法解析時拋 [FormatException]。
+  factory Rational.fromDecimalString(String input) {
+    final text = input.trim();
+    if (text.isEmpty) {
+      throw const FormatException('Empty rational input.');
+    }
+    var negative = false;
+    var body = text;
+    if (body.startsWith('-')) {
+      negative = true;
+      body = body.substring(1);
+    } else if (body.startsWith('+')) {
+      body = body.substring(1);
+    }
+    if (body.isEmpty || body == '.') {
+      throw FormatException('Invalid rational input: "$input".');
+    }
+    final dotIndex = body.indexOf('.');
+    if (dotIndex < 0) {
+      // 純整數。
+      final value = BigInt.parse(body);
+      return Rational.reduce(negative ? -value : value, BigInt.one);
+    }
+    final intPart = dotIndex == 0 ? '0' : body.substring(0, dotIndex);
+    final fracPart = body.substring(dotIndex + 1);
+    if (intPart.isEmpty && fracPart.isEmpty) {
+      throw FormatException('Invalid rational input: "$input".');
+    }
+    // 去掉尾端零以縮小分母，但空白小數部分視為 0。
+    final fracDigits = fracPart.isEmpty ? '' : fracPart.replaceFirst(
+      RegExp(r'0+$'),
+      '',
+    );
+    final intMagnitude = BigInt.parse(intPart.isEmpty ? '0' : intPart);
+    if (fracDigits.isEmpty) {
+      final value = intMagnitude;
+      return Rational.reduce(negative ? -value : value, BigInt.one);
+    }
+    final fracValue = BigInt.parse(fracDigits);
+    final denominator = BigInt.from(10).pow(fracDigits.length);
+    final combined = intMagnitude * denominator + fracValue;
+    return Rational.reduce(
+      negative ? -combined : combined,
+      denominator,
+    );
+  }
+
+  // ---- 算術 --------------------------------------------------------------
+
+  Rational operator +(Rational other) => Rational.reduce(
+    numerator * other.denominator + other.numerator * denominator,
+    denominator * other.denominator,
+  );
+
+  Rational operator -(Rational other) => Rational.reduce(
+    numerator * other.denominator - other.numerator * denominator,
+    denominator * other.denominator,
+  );
+
+  Rational operator *(Rational other) =>
+      Rational.reduce(numerator * other.numerator, denominator * other.denominator);
+
+  Rational operator /(Rational other) => Rational.reduce(
+    numerator * other.denominator,
+    denominator * other.numerator,
+  );
+
+  /// 取負號。
+  Rational operator -() => Rational._raw(-numerator, denominator);
+
+  /// 倒數（1 / this）。this 為 0 時拋 [FormatException]。
+  Rational reciprocal() {
+    if (isZero) {
+      throw const FormatException('Cannot take reciprocal of zero.');
+    }
+    // reduce 會處理分母為負的情況。
+    return Rational.reduce(denominator, numerator);
+  }
+
+  Rational abs() => isNegative ? -this : this;
+
+  bool get isNegative => numerator.isNegative;
+
+  @override
+  int compareTo(Rational other) {
+    // 分母為正，比較交叉相乘的結果。
+    final left = numerator * other.denominator;
+    final right = other.numerator * denominator;
+    return left.compareTo(right);
+  }
+
+  bool operator <(Rational other) => compareTo(other) < 0;
+  bool operator <=(Rational other) => compareTo(other) <= 0;
+  bool operator >(Rational other) => compareTo(other) > 0;
+  bool operator >=(Rational other) => compareTo(other) >= 0;
+
+  /// 取整數部份（向零截斷），例如 `7/3 -> 2`、`-7/3 -> -2`。
+  BigInt truncateToBigInt() => numerator ~/ denominator;
+
+  /// 取分數部份的絕對值（永遠 >= 0 且 < 1），例如 `7/3 -> 1/3`、
+  /// `-7/3 -> 1/3`。
+  Rational fractionalPartAbs() {
+    final truncated = truncateToBigInt();
+    return Rational.reduce(
+      (numerator - truncated * denominator).abs(),
+      denominator,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is Rational &&
+        numerator == other.numerator &&
+        denominator == other.denominator;
+  }
+
+  @override
+  int get hashCode => Object.hash(numerator, denominator);
+
+  @override
+  String toString() => isInteger ? '$numerator' : '$numerator/$denominator';
+}
+
+/// 對 [BigInt] 取整數平方根（無條件進位捨棄小數部份）。
+///
+/// 例如 `bigIntSqrt(BigInt.from(12)) == BigInt.from(3)`、
+/// `bigIntSqrt(BigInt.from(16)) == BigInt.from(4)`。
+BigInt bigIntSqrt(BigInt n) {
+  if (n < BigInt.zero) {
+    throw ArgumentError('square root of negative number');
+  }
+  if (n < BigInt.two) {
+    return n;
+  }
+  // 牛頓法（整數版），收斂快速且穩定。
+  var x = n;
+  var y = (x + BigInt.one) ~/ BigInt.two;
+  while (y < x) {
+    x = y;
+    y = (x + n ~/ x) ~/ BigInt.two;
+  }
+  return x;
+}
+
+/// 判斷 [n] 是否為完全平方數。
+bool isPerfectSquare(BigInt n) {
+  if (n < BigInt.zero) return false;
+  final root = bigIntSqrt(n);
+  return root * root == n;
+}
+
+/// 計算 [a] 的非負整數次方 [n]；`n < 0` 時拋 [ArgumentError]。
+BigInt bigIntPow(BigInt a, int n) {
+  if (n < 0) {
+    throw ArgumentError('bigIntPow does not support negative exponents');
+  }
+  var result = BigInt.one;
+  var base = a;
+  var exp = n;
+  while (exp > 0) {
+    if (exp & 1 == 1) {
+      result *= base;
+    }
+    exp >>= 1;
+    if (exp > 0) {
+      base *= base;
+    }
+  }
+  return result;
+}
+
+/// 整數 [n] 的整數立方根（向零截斷）。僅供 `ExactValueEvaluator` 判斷
+/// `³√x` 是否為整數時偶爾需要的近似檢查使用。
+BigInt bigIntCbrt(BigInt n) {
+  if (n == BigInt.zero) return BigInt.zero;
+  final negative = n.isNegative;
+  final abs = n.abs();
+  // 以 double 估計後再用牛頓法修正。
+  var x = BigInt.from(math.pow(abs.toDouble(), 1.0 / 3.0).ceil());
+  if (x == BigInt.zero) x = BigInt.one;
+  // 單調收敛：找到最大的 x 使 x^3 <= abs。
+  while (bigIntPow(x, 3) > abs) {
+    x -= BigInt.one;
+  }
+  while (bigIntPow(x + BigInt.one, 3) <= abs) {
+    x += BigInt.one;
+  }
+  return negative ? -x : x;
+}

--- a/lib/features/calculator/service/tree_calculator_engine.dart
+++ b/lib/features/calculator/service/tree_calculator_engine.dart
@@ -1,9 +1,12 @@
+import '../../../app/result_format_settings.dart';
 import '../../../core/errors/calculator_exception.dart';
 import '../../../core/math/angle_mode.dart';
 import '../../../core/math/result_formatter.dart';
 import '../model/calculation_result.dart';
 import '../model/expression/node/sequence_node.dart';
 import '../model/expression/validation_failure.dart';
+import 'exact_math/exact_value_evaluator.dart';
+import 'exact_math/exact_value_formatter.dart';
 import 'expression_compiler.dart';
 import 'expression_validator.dart';
 import 'tree_expression_evaluator.dart';
@@ -25,15 +28,21 @@ class TreeCalculatorEngine {
     this.validator = const ExpressionValidator(),
     this.compiler = const ExpressionCompiler(),
     this.evaluator = const TreeExpressionEvaluator(),
+    this.exactFormatter = const ExactValueFormatter(),
   });
 
   final ExpressionValidator validator;
   final ExpressionCompiler compiler;
   final TreeExpressionEvaluator evaluator;
+  final ExactValueFormatter exactFormatter;
 
   /// 求值 [root] Tree。
   ///
   /// [answer] 為上一個答案，供 `Ans` 常數使用；`null` 表示尚無答案。
+  /// [resultFormat] 控制顯示格式：[ResultFormatPreference.fraction] 時會嘗試
+  /// 以最簡分數／帶分數／根式（TeX）表示結果，無法精確化簡時 [formattedTex]
+  /// 為 `null`，由 UI 退回小數顯示。數值 [CalculationResult.value] 恆為小數
+  /// `double`，使 `Ans` 在兩種模式下保持一致。
   ///
   /// 拋出 [CalculatorException]（含 domain error 型別）供 ViewModel 放入
   /// ResultDisplay。
@@ -41,6 +50,7 @@ class TreeCalculatorEngine {
     SequenceNode root, {
     required AngleMode angleMode,
     double? answer,
+    ResultFormatPreference resultFormat = ResultFormatPreference.decimal,
   }) {
     final failure = validator.validate(root, hasAnswer: answer != null);
     if (failure != null) {
@@ -58,7 +68,25 @@ class TreeCalculatorEngine {
     return CalculationResult(
       value: value,
       formattedValue: ResultFormatter.format(value),
+      formattedTex: _tryExactTex(root, answer: answer, resultFormat: resultFormat),
     );
+  }
+
+  /// 在「分數」模式下嘗試以 [ExactValueEvaluator] 精確求值並格式化為 TeX；
+  /// 失敗（或非分數模式）回傳 `null`。
+  String? _tryExactTex(
+    SequenceNode root, {
+    double? answer,
+    required ResultFormatPreference resultFormat,
+  }) {
+    if (resultFormat != ResultFormatPreference.fraction) {
+      return null;
+    }
+    final evaluated = ExactValueEvaluator(answer: answer).evaluate(root);
+    if (evaluated == null) {
+      return null;
+    }
+    return exactFormatter.format(evaluated);
   }
 
   CalculatorException _toException(ValidationFailure failure) {

--- a/lib/features/calculator/view/calculator_screen.dart
+++ b/lib/features/calculator/view/calculator_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../app/always_on_top_settings.dart';
+import '../../../../app/result_format_settings.dart';
 import '../viewmodel/calculator_providers.dart';
 import 'calculator_keyboard_input_enabled_provider.dart';
 import 'widgets/calculator_keypad.dart';
@@ -10,6 +11,7 @@ import 'widgets/mode_indicator.dart';
 import 'widgets/natural_math_display.dart';
 import 'widgets/pin_button.dart';
 import 'widgets/result_display.dart';
+import 'widgets/result_format_indicator.dart';
 import 'widgets/settings_button.dart';
 
 class CalculatorScreen extends ConsumerWidget {
@@ -20,6 +22,7 @@ class CalculatorScreen extends ConsumerWidget {
     final state = ref.watch(calculatorViewModelProvider);
     final viewModel = ref.read(calculatorViewModelProvider.notifier);
     final serializer = ref.watch(treeExpressionTexSerializerProvider);
+    final resultFormat = ref.watch(resultFormatSettingsProvider);
 
     // TeX 完全由 Tree Serializer 產生；按 `=` 後游標不顯示。
     final texResult = serializer.serialize(
@@ -46,6 +49,13 @@ class CalculatorScreen extends ConsumerWidget {
               child: ModeIndicator(
                 angleMode: state.angleMode,
                 onPressed: viewModel.toggleAngleMode,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: ResultFormatIndicator(
+                resultFormat: resultFormat,
+                onPressed: viewModel.toggleResultFormat,
               ),
             ),
             const Padding(
@@ -75,6 +85,7 @@ class CalculatorScreen extends ConsumerWidget {
                         ResultDisplay(
                           result: state.result?.formattedValue,
                           errorMessage: state.errorMessage,
+                          tex: state.result?.formattedTex,
                         ),
                       ],
                     ),

--- a/lib/features/calculator/view/widgets/result_display.dart
+++ b/lib/features/calculator/view/widgets/result_display.dart
@@ -1,34 +1,80 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_math_fork/flutter_math.dart';
 
+/// 計算結果顯示區。
+///
+/// 顯示規則：
+/// - 有錯誤訊息 -> 顯示錯誤（error 色）。
+/// - 有 [tex]（分數模式下可精確化簡的結果）-> 以 `flutter_math_fork` 渲染
+///   最簡分數／帶分數／根式；水平置右、可橫向捲動。
+/// - 否則 -> 顯示 [result] 純文字（小數），無結果時顯示 `0`。
 class ResultDisplay extends StatelessWidget {
   const ResultDisplay({
     required this.result,
     required this.errorMessage,
+    this.tex,
     super.key,
   });
 
   final String? result;
   final String? errorMessage;
 
+  /// 精確結果的 TeX；為 `null` 時退回 [result] 純文字顯示。
+  final String? tex;
+
   @override
   Widget build(BuildContext context) {
     final hasError = errorMessage != null;
+    final theme = Theme.of(context);
+    final baseStyle = theme.textTheme.headlineMedium?.copyWith(
+      fontWeight: FontWeight.w600,
+    );
+    final color = hasError
+        ? theme.colorScheme.error
+        : theme.colorScheme.onSurface;
+
+    final Widget content;
+    if (hasError) {
+      content = Text(
+        errorMessage!,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.right,
+        style: baseStyle?.copyWith(color: color),
+      );
+    } else if (tex != null) {
+      content = SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        reverse: true,
+        child: Math.tex(
+          tex!,
+          mathStyle: MathStyle.text,
+          textStyle: baseStyle?.copyWith(color: color),
+          onErrorFallback: (_) => Text(
+            result ?? '0',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.right,
+            style: baseStyle?.copyWith(color: color),
+          ),
+        ),
+      );
+    } else {
+      content = Text(
+        result ?? '0',
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.right,
+        style: baseStyle?.copyWith(color: color),
+      );
+    }
 
     return Container(
       width: double.infinity,
       constraints: const BoxConstraints(minHeight: 72),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       alignment: Alignment.centerRight,
-      child: Text(
-        hasError ? errorMessage! : result ?? '0',
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-        textAlign: TextAlign.right,
-        style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-          color: hasError ? Theme.of(context).colorScheme.error : null,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
+      child: content,
     );
   }
 }

--- a/lib/features/calculator/view/widgets/result_format_indicator.dart
+++ b/lib/features/calculator/view/widgets/result_format_indicator.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import '../../../../app/result_format_settings.dart';
+
+/// 結果顯示格式切換鈕（DEC / FRAC），樣式與 [ModeIndicator]（DEG/RAD）一致。
+class ResultFormatIndicator extends StatelessWidget {
+  const ResultFormatIndicator({
+    required this.resultFormat,
+    required this.onPressed,
+    super.key,
+  });
+
+  final ResultFormatPreference resultFormat;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      label: Text(resultFormat.label),
+      avatar: const Icon(Icons.calculate, size: 18),
+      onPressed: onPressed,
+    );
+  }
+}

--- a/lib/features/calculator/viewmodel/calculator_view_model.dart
+++ b/lib/features/calculator/viewmodel/calculator_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../app/result_format_settings.dart';
 import '../../../core/errors/calculator_exception.dart';
 import '../../../core/math/angle_mode.dart';
 import '../model/calculator_state.dart';
@@ -174,11 +175,18 @@ class CalculatorViewModel extends Notifier<CalculatorState> {
   // ---- 計算 ---------------------------------------------------------------
 
   void calculate() {
+    _evaluate(document: state.document);
+  }
+
+  /// 以給定 [document] 求值，並更新 state（成功時放入結果、清錯誤）。
+  void _evaluate({required ExpressionDocument document}) {
+    final resultFormat = ref.read(resultFormatSettingsProvider);
     try {
       final result = _engine.evaluate(
-        state.document.root,
+        document.root,
         angleMode: state.angleMode,
         answer: state.answer,
+        resultFormat: resultFormat,
       );
       state = state.copyWith(
         result: result,
@@ -202,6 +210,25 @@ class CalculatorViewModel extends Notifier<CalculatorState> {
         ? AngleMode.radian
         : AngleMode.degree;
     state = state.copyWith(angleMode: nextMode, clearError: true);
+  }
+
+  // ---- 結果顯示格式 -------------------------------------------------------
+
+  /// 切換 DEC / FRAC 顯示格式。
+  ///
+  /// 切換後若目前已有結果，會以新格式重新求值同一算式，讓顯示即時更新，
+  /// 不需要再按一次 `=`。
+  Future<void> toggleResultFormat() async {
+    final current = ref.read(resultFormatSettingsProvider);
+    final next = current == ResultFormatPreference.decimal
+        ? ResultFormatPreference.fraction
+        : ResultFormatPreference.decimal;
+    await ref.read(resultFormatSettingsProvider.notifier).set(next);
+
+    // 若已有結果，以新格式重新求值。錯誤狀態（errorMessage）不重新計算。
+    if (state.result != null && state.errorMessage == null) {
+      _evaluate(document: state.document);
+    }
   }
 
   // ---- helpers ------------------------------------------------------------

--- a/test/app/result_format_settings_test.dart
+++ b/test/app/result_format_settings_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/app/result_format_settings.dart';
+
+import '../helpers/shared_preferences_test_helper.dart';
+
+/// 結果顯示格式偏好持久化與 Notifier 測試（鏡像 theme_settings_test.dart）。
+void main() {
+  group('ResultFormatPreference', () {
+    test('label 對應', () {
+      expect(ResultFormatPreference.decimal.label, 'DEC');
+      expect(ResultFormatPreference.fraction.label, 'FRAC');
+    });
+
+    test('fromName 只接受已知值，其餘回傳 decimal', () {
+      expect(
+        ResultFormatPreference.fromName('fraction'),
+        ResultFormatPreference.fraction,
+      );
+      expect(
+        ResultFormatPreference.fromName('decimal'),
+        ResultFormatPreference.decimal,
+      );
+      expect(ResultFormatPreference.fromName(null), ResultFormatPreference.decimal);
+      expect(
+        ResultFormatPreference.fromName('garbage'),
+        ResultFormatPreference.decimal,
+      );
+    });
+  });
+
+  group('ResultFormatSettingsStorage', () {
+    setUp(setupSharedPreferencesForTest);
+
+    test('未儲存時 load 回傳 decimal', () async {
+      expect(
+        await ResultFormatSettingsStorage.load(),
+        ResultFormatPreference.decimal,
+      );
+    });
+
+    test('save 後可 load 回相同值', () async {
+      await ResultFormatSettingsStorage.save(ResultFormatPreference.fraction);
+      expect(
+        await ResultFormatSettingsStorage.load(),
+        ResultFormatPreference.fraction,
+      );
+
+      await ResultFormatSettingsStorage.save(ResultFormatPreference.decimal);
+      expect(
+        await ResultFormatSettingsStorage.load(),
+        ResultFormatPreference.decimal,
+      );
+    });
+  });
+
+  group('ResultFormatSettingsNotifier', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      setupSharedPreferencesForTest();
+      container = ProviderContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    test('初始值預設為 decimal', () {
+      expect(
+        container.read(resultFormatSettingsProvider),
+        ResultFormatPreference.decimal,
+      );
+    });
+
+    test('initialResultFormatPreferenceProvider override 可改變初始值', () {
+      final overridden = ProviderContainer(
+        overrides: [
+          initialResultFormatPreferenceProvider.overrideWith(
+            (ref) => ResultFormatPreference.fraction,
+          ),
+        ],
+      );
+      addTearDown(overridden.dispose);
+
+      expect(
+        overridden.read(resultFormatSettingsProvider),
+        ResultFormatPreference.fraction,
+      );
+    });
+
+    test('set 更新 state 並持久化', () async {
+      final notifier = container.read(resultFormatSettingsProvider.notifier);
+
+      await notifier.set(ResultFormatPreference.fraction);
+
+      expect(
+        container.read(resultFormatSettingsProvider),
+        ResultFormatPreference.fraction,
+      );
+      expect(
+        await ResultFormatSettingsStorage.load(),
+        ResultFormatPreference.fraction,
+      );
+    });
+
+    test('set 相同值不重複寫入', () async {
+      final notifier = container.read(resultFormatSettingsProvider.notifier);
+
+      await notifier.set(ResultFormatPreference.decimal);
+
+      expect(
+        container.read(resultFormatSettingsProvider),
+        ResultFormatPreference.decimal,
+      );
+    });
+  });
+}

--- a/test/features/calculator/service/exact_math/exact_number_test.dart
+++ b/test/features/calculator/service/exact_math/exact_number_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/exact_number.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/rational.dart';
+
+void main() {
+  final one = Rational.one;
+  final two = Rational.fromInt(2);
+  final three = Rational.fromInt(3);
+
+  ExactNumber surd(BigInt radicand, Rational coeff) =>
+      ExactNumber.fromTerms({radicand: coeff});
+
+  group('ExactNumber construction', () {
+    test('fromTerms 去除 0 係數', () {
+      final n = ExactNumber.fromTerms({BigInt.one: Rational.zero, BigInt.two: one});
+      expect(n.surdTerms.length, 1);
+      expect(n.surdTerms.single.key, BigInt.two);
+    });
+
+    test('isZero / isRational', () {
+      expect(ExactNumber.zero.isZero, isTrue);
+      expect(ExactNumber.fromInt(5).isRational, isTrue);
+      expect(surd(BigInt.two, one).isRational, isFalse);
+      // 有理 + 根號 -> 非 rational。
+      final mixed = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: one});
+      expect(mixed.isRational, isFalse);
+    });
+  });
+
+  group('ExactNumber add/sub', () {
+    test('合併相同 radicand', () {
+      // 2√3 + √3 = 3√3
+      final sum = surd(BigInt.from(3), two) + surd(BigInt.from(3), one);
+      expect(sum, surd(BigInt.from(3), three));
+    });
+
+    test('不同 radicand 並存', () {
+      // √2 + √3
+      final sum = surd(BigInt.two, one) + surd(BigInt.from(3), one);
+      expect(sum.surdTerms.length, 2);
+    });
+
+    test('相加為 0 時項被移除', () {
+      // √2 - √2 = 0
+      final result = surd(BigInt.two, one) - surd(BigInt.two, one);
+      expect(result.isZero, isTrue);
+    });
+  });
+
+  group('ExactNumber mul (square-free simplification)', () {
+    test('√2 * √8 = 4（完全平方）', () {
+      final result = surd(BigInt.two, one) * surd(BigInt.from(8), one);
+      expect(result, ExactNumber.fromInt(4));
+    });
+
+    test('√2 * √3 = √6', () {
+      final result = surd(BigInt.two, one) * surd(BigInt.from(3), one);
+      expect(result, surd(BigInt.from(6), one));
+    });
+
+    test('2√3 * √3 = 6', () {
+      final result = surd(BigInt.from(3), two) * surd(BigInt.from(3), one);
+      expect(result, ExactNumber.fromInt(6));
+    });
+
+    test('(1+√2) * (1-√2) = -1（共軛相乘）', () {
+      final a = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: one});
+      final b = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: Rational.fromInt(-1)});
+      expect(a * b, ExactNumber.fromInt(-1));
+    });
+  });
+
+  group('ExactNumber divide (rationalization)', () {
+    test('純有理分母逐項除', () {
+      // (1 + √2) / 2
+      final num = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: one});
+      final result = num.divide(ExactNumber.fromInt(2));
+      expect(result, ExactNumber.fromTerms({
+        BigInt.one: Rational.reduce(BigInt.one, BigInt.two),
+        BigInt.two: Rational.reduce(BigInt.one, BigInt.two),
+      }));
+    });
+
+    test('單根號項分母 c√d：1/√2 = √2/2', () {
+      final result = ExactNumber.fromInt(1).divide(surd(BigInt.two, one));
+      expect(result, surd(BigInt.two, Rational.reduce(BigInt.one, BigInt.two)));
+    });
+
+    test('兩項分母 a+b√d：1/(1+√2) = √2-1', () {
+      final denom = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: one});
+      final result = ExactNumber.fromInt(1).divide(denom);
+      // 1/(1+√2) = (√2 - 1) / ((1+√2)(√2-1)) = (√2-1)/(2-1) = √2 - 1
+      expect(result, ExactNumber.fromTerms({
+        BigInt.one: Rational.fromInt(-1),
+        BigInt.two: Rational.one,
+      }));
+    });
+
+    test('三項以上根號項分母無法有理化 -> null', () {
+      final denom = ExactNumber.fromTerms({
+        BigInt.one: one,
+        BigInt.two: one,
+        BigInt.from(3): one,
+      });
+      expect(ExactNumber.fromInt(1).divide(denom), isNull);
+    });
+
+    test('除以 0 -> null', () {
+      expect(ExactNumber.fromInt(5).divide(ExactNumber.zero), isNull);
+    });
+  });
+
+  group('ExactNumber pow', () {
+    test('(1+√2)^2 = 3+2√2', () {
+      final base = ExactNumber.fromTerms({BigInt.one: one, BigInt.two: one});
+      final result = base.pow(2);
+      expect(result, ExactNumber.fromTerms({
+        BigInt.one: Rational.fromInt(3),
+        BigInt.two: Rational.fromInt(2),
+      }));
+    });
+
+    test('√3^4 = 9', () {
+      expect(surd(BigInt.from(3), one).pow(4), ExactNumber.fromInt(9));
+    });
+  });
+
+  group('sqrtOf (square-free extraction)', () {
+    test('√12 = 2√3', () {
+      expect(sqrtOf(BigInt.from(12)), surd(BigInt.from(3), two));
+    });
+
+    test('√18 = 3√2', () {
+      expect(sqrtOf(BigInt.from(18)), surd(BigInt.two, Rational.fromInt(3)));
+    });
+
+    test('√50 = 5√2', () {
+      expect(sqrtOf(BigInt.from(50)), surd(BigInt.two, Rational.fromInt(5)));
+    });
+
+    test('√72 = 6√2', () {
+      expect(sqrtOf(BigInt.from(72)), surd(BigInt.two, Rational.fromInt(6)));
+    });
+
+    test('√16 = 4（完全平方 -> 純整數）', () {
+      expect(sqrtOf(BigInt.from(16)), ExactNumber.fromInt(4));
+    });
+
+    test('√0 = 0', () {
+      expect(sqrtOf(BigInt.zero), ExactNumber.zero);
+    });
+
+    test('負數 -> null', () {
+      expect(sqrtOf(BigInt.from(-1)), isNull);
+    });
+
+    test('√48 = 4√3（驗證使用者原始範例的正確化簡）', () {
+      // 注意：使用者誤寫 √12=4√3，正確為 √12=2√3；√48=4√3。
+      expect(sqrtOf(BigInt.from(48)), surd(BigInt.from(3), Rational.fromInt(4)));
+    });
+  });
+
+  group('sqrtOfRational', () {
+    test('√(1/4) = 1/2', () {
+      expect(
+        sqrtOfRational(Rational.reduce(BigInt.one, BigInt.from(4))),
+        ExactNumber.rational(Rational.reduce(BigInt.one, BigInt.two)),
+      );
+    });
+
+    test('√(12/1) = 2√3', () {
+      expect(
+        sqrtOfRational(Rational.fromInt(12)),
+        surd(BigInt.from(3), two),
+      );
+    });
+
+    test('√(2/3) = √6/3（有理化分母）', () {
+      // √(2/3) = √2/√3 = (√2·√3)/3 = √6/3
+      expect(
+        sqrtOfRational(Rational.reduce(BigInt.two, BigInt.from(3))),
+        surd(BigInt.from(6), Rational.reduce(BigInt.one, BigInt.from(3))),
+      );
+    });
+
+    test('負數 -> null', () {
+      expect(sqrtOfRational(Rational.fromInt(-4)), isNull);
+    });
+  });
+
+  group('toDouble (approximation)', () {
+    test('2√3 ≈ 3.4641', () {
+      final approx = surd(BigInt.from(3), two).toDouble();
+      expect((approx - 3.46410161514).abs(), lessThan(1e-9));
+    });
+
+    test('1 + 1/2 = 1.5', () {
+      expect(
+        ExactNumber.rational(Rational.reduce(BigInt.from(3), BigInt.two)).toDouble(),
+        1.5,
+      );
+    });
+  });
+}

--- a/test/features/calculator/service/exact_math/exact_value_evaluator_test.dart
+++ b/test/features/calculator/service/exact_math/exact_value_evaluator_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/expression_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/constant_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/fraction_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/function_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/group_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/number_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/operator_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/power_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/root_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node/sequence_node.dart';
+import 'package:scientific_calculator/features/calculator/model/expression/node_id.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/exact_number.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/exact_value_evaluator.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/rational.dart';
+
+void main() {
+  const evaluator = ExactValueEvaluator();
+
+  SequenceNode seq(List<ExpressionNode> children) =>
+      SequenceNode(id: NodeId.generate(), children: children);
+
+  ExactNumber intNum(int v) => ExactNumber.fromInt(v);
+  ExactNumber rational(int n, int d) =>
+      ExactNumber.rational(Rational.reduce(BigInt.from(n), BigInt.from(d)));
+  ExactNumber surd(int radicand, int coeff) =>
+      ExactNumber.fromTerms({BigInt.from(radicand): Rational.fromInt(coeff)});
+
+  group('基本算術', () {
+    test('2 + 3 -> 5', () {
+      final root = seq([
+        NumberNode.create('2'),
+        OperatorNode.create(ExpressionOperator.add),
+        NumberNode.create('3'),
+      ]);
+      expect(evaluator.evaluate(root), intNum(5));
+    });
+
+    test('7 / 3 -> 7/3（未化簡帶分數，由 formatter 處理）', () {
+      final root = seq([
+        NumberNode.create('7'),
+        OperatorNode.create(ExpressionOperator.divide),
+        NumberNode.create('3'),
+      ]);
+      expect(evaluator.evaluate(root), rational(7, 3));
+    });
+
+    test('2.5 + 0.5 -> 3', () {
+      final root = seq([
+        NumberNode.create('2.5'),
+        OperatorNode.create(ExpressionOperator.add),
+        NumberNode.create('0.5'),
+      ]);
+      expect(evaluator.evaluate(root), intNum(3));
+    });
+
+    test('負號（unary minus）', () {
+      final root = seq([
+        OperatorNode.create(ExpressionOperator.subtract),
+        NumberNode.create('5'),
+      ]);
+      expect(evaluator.evaluate(root), intNum(-5));
+    });
+
+    test('運算子優先順序：2 + 3 * 4 -> 14', () {
+      final root = seq([
+        NumberNode.create('2'),
+        OperatorNode.create(ExpressionOperator.add),
+        NumberNode.create('3'),
+        OperatorNode.create(ExpressionOperator.multiply),
+        NumberNode.create('4'),
+      ]);
+      expect(evaluator.evaluate(root), intNum(14));
+    });
+  });
+
+  group('分數節點 FractionNode', () {
+    test('4/3 -> 4/3', () {
+      final frac = FractionNode(
+        id: NodeId.generate(),
+        numerator: seq([NumberNode.create('4')]),
+        denominator: seq([NumberNode.create('3')]),
+      );
+      expect(evaluator.evaluate(seq([frac])), rational(4, 3));
+    });
+
+    test('分數內含運算：(1+2)/(3+4) -> 3/7', () {
+      final frac = FractionNode(
+        id: NodeId.generate(),
+        numerator: seq([
+          NumberNode.create('1'),
+          OperatorNode.create(ExpressionOperator.add),
+          NumberNode.create('2'),
+        ]),
+        denominator: seq([
+          NumberNode.create('3'),
+          OperatorNode.create(ExpressionOperator.add),
+          NumberNode.create('4'),
+        ]),
+      );
+      expect(evaluator.evaluate(seq([frac])), rational(3, 7));
+    });
+  });
+
+  group('根號節點 RootNode（平方根）', () {
+    test('√12 -> 2√3', () {
+      final root = seq([
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('12')])),
+      ]);
+      expect(evaluator.evaluate(root), surd(3, 2));
+    });
+
+    test('√18 -> 3√2', () {
+      final root = seq([
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('18')])),
+      ]);
+      expect(evaluator.evaluate(root), surd(2, 3));
+    });
+
+    test('√16 -> 4（完全平方）', () {
+      final root = seq([
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('16')])),
+      ]);
+      expect(evaluator.evaluate(root), intNum(4));
+    });
+
+    test('√2 + √3 -> √2 + √3', () {
+      final root = seq([
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('2')])),
+        OperatorNode.create(ExpressionOperator.add),
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('3')])),
+      ]);
+      final result = evaluator.evaluate(root)!;
+      expect(result.surdTerms.length, 2);
+    });
+
+    test('1/√2 -> √2/2（有理化）', () {
+      final frac = FractionNode(
+        id: NodeId.generate(),
+        numerator: seq([NumberNode.create('1')]),
+        denominator: seq([
+          RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('2')])),
+        ]),
+      );
+      // 1/√2 = √2/2，即 (1/2)√2。
+      expect(
+        evaluator.evaluate(seq([frac])),
+        ExactNumber.fromTerms({BigInt.two: Rational.reduce(BigInt.one, BigInt.two)}),
+      );
+    });
+
+    test('n 次根（degree 已設）-> null（fallback）', () {
+      final root = seq([
+        RootNode(
+          id: NodeId.generate(),
+          radicand: seq([NumberNode.create('8')]),
+          degree: seq([NumberNode.create('3')]),
+        ),
+      ]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+
+    test('√(-1) -> null（實數範圍無定義）', () {
+      final root = seq([
+        RootNode(
+          id: NodeId.generate(),
+          radicand: seq([
+            OperatorNode.create(ExpressionOperator.subtract),
+            NumberNode.create('1'),
+          ]),
+        ),
+      ]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+  });
+
+  group('指數節點 PowerNode', () {
+    PowerNode power(String base, String exp) => PowerNode(
+      id: NodeId.generate(),
+      base: seq([NumberNode.create(base)]),
+      exponent: seq([NumberNode.create(exp)]),
+    );
+
+    test('5^2 -> 25', () {
+      expect(evaluator.evaluate(seq([power('5', '2')])), intNum(25));
+    });
+
+    test('(1+√2)^2 -> 3+2√2', () {
+      final base = seq([
+        NumberNode.create('1'),
+        OperatorNode.create(ExpressionOperator.add),
+        RootNode(id: NodeId.generate(), radicand: seq([NumberNode.create('2')])),
+      ]);
+      final pow = PowerNode(
+        id: NodeId.generate(),
+        base: base,
+        exponent: seq([NumberNode.create('2')]),
+      );
+      final result = evaluator.evaluate(seq([pow]))!;
+      expect(result.rationalPart, Rational.fromInt(3));
+      expect(result.surdTerms.single.value, Rational.fromInt(2));
+    });
+
+    test('2^-1 -> 1/2（負整數次方）', () {
+      expect(evaluator.evaluate(seq([power('2', '-1')])), rational(1, 2));
+    });
+
+    test('非整數次方 -> null', () {
+      expect(evaluator.evaluate(seq([power('2', '0.5')])), isNull);
+    });
+  });
+
+  group('bail-out（無法精確表示）', () {
+    test('π 常數 -> null', () {
+      final root = seq([ConstantNode.create(MathConstant.pi)]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+
+    test('e 常數 -> null', () {
+      final root = seq([ConstantNode.create(MathConstant.e)]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+
+    test('sin(30) -> null', () {
+      final root = seq([
+        FunctionNode(
+          id: NodeId.generate(),
+          function: MathFunction.sin,
+          argument: seq([NumberNode.create('30')]),
+        ),
+      ]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+
+    test('ln(e) -> null', () {
+      final root = seq([
+        FunctionNode(
+          id: NodeId.generate(),
+          function: MathFunction.ln,
+          argument: seq([ConstantNode.create(MathConstant.e)]),
+        ),
+      ]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+
+    test('2 + π -> null（牽涉超越數）', () {
+      final root = seq([
+        NumberNode.create('2'),
+        OperatorNode.create(ExpressionOperator.add),
+        ConstantNode.create(MathConstant.pi),
+      ]);
+      expect(evaluator.evaluate(root), isNull);
+    });
+  });
+
+  group('Ans 常數', () {
+    test('Ans 為整數時可精確使用', () {
+      final eval = ExactValueEvaluator(answer: 42);
+      final root = seq([ConstantNode.create(MathConstant.answer)]);
+      expect(eval.evaluate(root), intNum(42));
+    });
+
+    test('Ans 為小數時 -> null', () {
+      final eval = ExactValueEvaluator(answer: 2.5);
+      final root = seq([ConstantNode.create(MathConstant.answer)]);
+      expect(eval.evaluate(root), isNull);
+    });
+  });
+
+  group('群組 GroupNode', () {
+    test('(2 + 3) * 4 -> 20', () {
+      final group = GroupNode(
+        id: NodeId.generate(),
+        content: seq([
+          NumberNode.create('2'),
+          OperatorNode.create(ExpressionOperator.add),
+          NumberNode.create('3'),
+        ]),
+      );
+      final root = seq([
+        group,
+        OperatorNode.create(ExpressionOperator.multiply),
+        NumberNode.create('4'),
+      ]);
+      expect(evaluator.evaluate(root), intNum(20));
+    });
+  });
+}

--- a/test/features/calculator/service/exact_math/exact_value_formatter_test.dart
+++ b/test/features/calculator/service/exact_math/exact_value_formatter_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/exact_number.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/exact_value_formatter.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/rational.dart';
+
+void main() {
+  const formatter = ExactValueFormatter();
+
+  ExactNumber rational(int n, int d) =>
+      ExactNumber.rational(Rational.reduce(BigInt.from(n), BigInt.from(d)));
+  ExactNumber surd(int radicand, Rational coeff) =>
+      ExactNumber.fromTerms({BigInt.from(radicand): coeff});
+
+  group('純有理數', () {
+    test('整數 -> null（純文字顯示）', () {
+      expect(formatter.format(ExactNumber.fromInt(5)), isNull);
+      expect(formatter.format(ExactNumber.fromInt(0)), isNull);
+      expect(formatter.format(ExactNumber.fromInt(-3)), isNull);
+    });
+
+    test('真分數 1/3 -> \\frac{1}{3}', () {
+      expect(formatter.format(rational(1, 3)), r'\frac{1}{3}');
+    });
+
+    test('負真分數 -1/3 -> \\frac{-1}{3}', () {
+      expect(formatter.format(rational(-1, 3)), r'\frac{-1}{3}');
+    });
+
+    test('帶分數 4/3 -> 1\\frac{1}{3}', () {
+      expect(formatter.format(rational(4, 3)), r'1\frac{1}{3}');
+    });
+
+    test('負帶分數 -7/3 -> -2\\frac{1}{3}', () {
+      expect(formatter.format(rational(-7, 3)), r'-2\frac{1}{3}');
+    });
+  });
+
+  group('純根號項', () {
+    test('√3 -> \\sqrt{3}', () {
+      expect(formatter.format(surd(3, Rational.one)), r'\sqrt{3}');
+    });
+
+    test('2√3 -> 2\\sqrt{3}', () {
+      expect(formatter.format(surd(3, Rational.fromInt(2))), r'2\sqrt{3}');
+    });
+
+    test('-√3 -> -\\sqrt{3}（係數 -1 省略數字）', () {
+      expect(formatter.format(surd(3, Rational.fromInt(-1))), r'-\sqrt{3}');
+    });
+
+    test('(1/2)√3 -> \\frac{1}{2}\\sqrt{3}', () {
+      expect(
+        formatter.format(surd(3, Rational.reduce(BigInt.one, BigInt.two))),
+        r'\frac{1}{2}\sqrt{3}',
+      );
+    });
+  });
+
+  group('有理 + 根號（帶符號組合）', () {
+    test('1 + √2 -> 1 + \\sqrt{2}（整數有理部份與根號並列時須保留）', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.one: Rational.one,
+        BigInt.two: Rational.one,
+      });
+      expect(formatter.format(value), r'1 + \sqrt{2}');
+    });
+
+    test('-1 + √2 -> -1 + \\sqrt{2}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.one: Rational.fromInt(-1),
+        BigInt.two: Rational.one,
+      });
+      expect(formatter.format(value), r'-1 + \sqrt{2}');
+    });
+
+    test('1/2 + √3 -> \\frac{1}{2} + \\sqrt{3}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.one: Rational.reduce(BigInt.one, BigInt.two),
+        BigInt.from(3): Rational.one,
+      });
+      expect(formatter.format(value), r'\frac{1}{2} + \sqrt{3}');
+    });
+
+    test('√2 + √3 -> \\sqrt{2} + \\sqrt{3}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.two: Rational.one,
+        BigInt.from(3): Rational.one,
+      });
+      expect(formatter.format(value), r'\sqrt{2} + \sqrt{3}');
+    });
+
+    test('√2 - √3 -> \\sqrt{2} - \\sqrt{3}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.two: Rational.one,
+        BigInt.from(3): Rational.fromInt(-1),
+      });
+      expect(formatter.format(value), r'\sqrt{2} - \sqrt{3}');
+    });
+
+    test('5 + 2√3 -> 5 + 2\\sqrt{3}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.one: Rational.fromInt(5),
+        BigInt.from(3): Rational.fromInt(2),
+      });
+      expect(formatter.format(value), r'5 + 2\sqrt{3}');
+    });
+
+    test('-5 + 2√3 -> -5 + 2\\sqrt{3}', () {
+      final value = ExactNumber.fromTerms({
+        BigInt.one: Rational.fromInt(-5),
+        BigInt.from(3): Rational.fromInt(2),
+      });
+      expect(formatter.format(value), r'-5 + 2\sqrt{3}');
+    });
+  });
+
+  group('退化情況', () {
+    test('0 -> null', () {
+      expect(formatter.format(ExactNumber.zero), isNull);
+    });
+  });
+}

--- a/test/features/calculator/service/exact_math/rational_test.dart
+++ b/test/features/calculator/service/exact_math/rational_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/features/calculator/service/exact_math/rational.dart';
+
+void main() {
+  group('Rational construction', () {
+    test('reduce 化為最簡並保證分母為正', () {
+      final r = Rational.reduce(BigInt.from(6), BigInt.from(8));
+      expect(r.numerator, BigInt.from(3));
+      expect(r.denominator, BigInt.from(4));
+
+      // 負分母移到分子。
+      final neg = Rational.reduce(BigInt.from(6), BigInt.from(-8));
+      expect(neg.numerator, BigInt.from(-3));
+      expect(neg.denominator, BigInt.from(4));
+
+      // 分子為 0 規範化為 0/1。
+      final zero = Rational.reduce(BigInt.zero, BigInt.from(5));
+      expect(zero.numerator, BigInt.zero);
+      expect(zero.denominator, BigInt.one);
+    });
+
+    test('零分母拋 FormatException', () {
+      expect(
+        () => Rational(BigInt.one, BigInt.zero),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => Rational.reduce(BigInt.one, BigInt.zero),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('Rational.fromDecimalString', () {
+    test('整數', () {
+      expect(Rational.fromDecimalString('2'), Rational.fromInt(2));
+      expect(Rational.fromDecimalString('0'), Rational.zero);
+      expect(Rational.fromDecimalString('-7'), Rational.fromInt(-7));
+      expect(Rational.fromDecimalString('+5'), Rational.fromInt(5));
+    });
+
+    test('小數精確化簡', () {
+      expect(Rational.fromDecimalString('2.5'), Rational.reduce(BigInt.from(5), BigInt.two));
+      expect(Rational.fromDecimalString('0.5'), Rational.reduce(BigInt.one, BigInt.two));
+      expect(Rational.fromDecimalString('3.14'), Rational.reduce(BigInt.from(157), BigInt.from(50)));
+      expect(Rational.fromDecimalString('1.25'), Rational.reduce(BigInt.from(5), BigInt.from(4)));
+      expect(Rational.fromDecimalString('-1.5'), Rational.reduce(BigInt.from(-3), BigInt.two));
+    });
+
+    test('尾端零縮小分母', () {
+      // 2.50 -> 5/2（而非 250/100）。
+      expect(Rational.fromDecimalString('2.50'), Rational.reduce(BigInt.from(5), BigInt.two));
+      expect(Rational.fromDecimalString('1.500'), Rational.reduce(BigInt.from(3), BigInt.two));
+    });
+
+    test('前導零與無整數部份', () {
+      expect(Rational.fromDecimalString('.5'), Rational.reduce(BigInt.one, BigInt.two));
+      expect(Rational.fromDecimalString('0.25'), Rational.reduce(BigInt.one, BigInt.from(4)));
+    });
+
+    test('非法輸入拋 FormatException', () {
+      expect(() => Rational.fromDecimalString(''), throwsA(isA<FormatException>()));
+      expect(() => Rational.fromDecimalString('.'), throwsA(isA<FormatException>()));
+      expect(() => Rational.fromDecimalString('abc'), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('Rational arithmetic', () {
+    final oneThird = Rational.reduce(BigInt.one, BigInt.from(3));
+    final twoThirds = Rational.reduce(BigInt.two, BigInt.from(3));
+
+    test('加法', () {
+      expect(oneThird + twoThirds, Rational.one);
+      expect(Rational.fromInt(2) + Rational.fromInt(3), Rational.fromInt(5));
+    });
+
+    test('減法', () {
+      expect(Rational.one - oneThird, twoThirds);
+      expect(twoThirds - oneThird, oneThird);
+    });
+
+    test('乘法', () {
+      expect(oneThird * Rational.fromInt(3), Rational.one);
+      expect(twoThirds * twoThirds, Rational.reduce(BigInt.from(4), BigInt.from(9)));
+    });
+
+    test('除法', () {
+      expect(Rational.fromInt(6) / Rational.fromInt(4), Rational.reduce(BigInt.from(3), BigInt.two));
+      expect(Rational.one / oneThird, Rational.fromInt(3));
+    });
+
+    test('倒數與負號', () {
+      expect(Rational.fromInt(4).reciprocal(), Rational.reduce(BigInt.one, BigInt.from(4)));
+      expect(-oneThird, Rational.reduce(BigInt.from(-1), BigInt.from(3)));
+    });
+
+    test('零的倒數拋例外', () {
+      expect(() => Rational.zero.reciprocal(), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('Rational helpers', () {
+    test('truncateToBigInt 與 fractionalPartAbs（帶分數用）', () {
+      final sevenThirds = Rational.reduce(BigInt.from(7), BigInt.from(3));
+      expect(sevenThirds.truncateToBigInt(), BigInt.two);
+      expect(sevenThirds.fractionalPartAbs(), oneThird);
+
+      final negSevenThirds = Rational.reduce(BigInt.from(-7), BigInt.from(3));
+      expect(negSevenThirds.truncateToBigInt(), BigInt.from(-2));
+      expect(negSevenThirds.fractionalPartAbs(), oneThird);
+    });
+
+    test('comparisons', () {
+      expect(Rational.fromInt(2) > Rational.fromInt(1), isTrue);
+      expect(oneThird < Rational.fromInt(1), isTrue);
+      expect(Rational.fromInt(3) <= Rational.fromInt(3), isTrue);
+      expect(Rational.fromInt(3) >= Rational.fromInt(3), isTrue);
+    });
+
+    test('isInteger / isZero / isNegative', () {
+      expect(Rational.fromInt(5).isInteger, isTrue);
+      expect(oneThird.isInteger, isFalse);
+      expect(Rational.zero.isZero, isTrue);
+      expect(Rational.fromInt(-5).isNegative, isTrue);
+      expect(oneThird.isNegative, isFalse);
+    });
+  });
+
+  group('BigInt helpers', () {
+    test('bigIntSqrt', () {
+      expect(bigIntSqrt(BigInt.from(0)), BigInt.zero);
+      expect(bigIntSqrt(BigInt.from(1)), BigInt.one);
+      expect(bigIntSqrt(BigInt.from(12)), BigInt.from(3));
+      expect(bigIntSqrt(BigInt.from(16)), BigInt.from(4));
+      expect(bigIntSqrt(BigInt.from(15)), BigInt.from(3));
+      expect(bigIntSqrt(BigInt.from(1000000)), BigInt.from(1000));
+    });
+
+    test('isPerfectSquare', () {
+      expect(isPerfectSquare(BigInt.from(16)), isTrue);
+      expect(isPerfectSquare(BigInt.from(15)), isFalse);
+      expect(isPerfectSquare(BigInt.from(0)), isTrue);
+      expect(isPerfectSquare(BigInt.from(-4)), isFalse);
+    });
+
+    test('bigIntPow', () {
+      expect(bigIntPow(BigInt.from(2), 10), BigInt.from(1024));
+      expect(bigIntPow(BigInt.from(3), 4), BigInt.from(81));
+      expect(bigIntPow(BigInt.from(5), 0), BigInt.one);
+    });
+  });
+}
+
+final Rational oneThird = Rational.reduce(BigInt.one, BigInt.from(3));

--- a/test/features/calculator/service/tree_calculator_engine_test.dart
+++ b/test/features/calculator/service/tree_calculator_engine_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:scientific_calculator/app/result_format_settings.dart';
 import 'package:scientific_calculator/core/errors/calculator_exception.dart';
 import 'package:scientific_calculator/core/math/angle_mode.dart';
 import 'package:scientific_calculator/features/calculator/model/expression/expression_node.dart';
@@ -407,6 +408,121 @@ void main() {
       ]);
       final result = engine.evaluate(root, angleMode: AngleMode.degree);
       expect(result.formattedValue, '5');
+    });
+  });
+
+  group('formattedTex（分數模式）', () {
+    test('decimal 模式 formattedTex 恆為 null', () {
+      final root = seq([
+        NumberNode.create('4'),
+        OperatorNode.create(ExpressionOperator.divide),
+        NumberNode.create('3'),
+      ]);
+      final result = engine.evaluate(root, angleMode: AngleMode.degree);
+      expect(result.formattedTex, isNull);
+    });
+
+    test('4/3 fraction 模式 -> 帶分數 TeX', () {
+      final root = seq([
+        NumberNode.create('4'),
+        OperatorNode.create(ExpressionOperator.divide),
+        NumberNode.create('3'),
+      ]);
+      final result = engine.evaluate(
+        root,
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, r'1\frac{1}{3}');
+      // 數值仍為小數，Ans 不受模式影響。
+      expectClose(result.value, 4 / 3);
+    });
+
+    test('√12 fraction 模式 -> 2\\sqrt{3}', () {
+      final root = seq([
+        RootNode(
+          id: NodeId.generate(),
+          radicand: seq([NumberNode.create('12')]),
+        ),
+      ]);
+      final result = engine.evaluate(
+        root,
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, r'2\sqrt{3}');
+    });
+
+    test('1/√2 fraction 模式 -> \\frac{1}{2}\\sqrt{2}（有理化）', () {
+      final frac = FractionNode(
+        id: NodeId.generate(),
+        numerator: seq([NumberNode.create('1')]),
+        denominator: seq([
+          RootNode(
+            id: NodeId.generate(),
+            radicand: seq([NumberNode.create('2')]),
+          ),
+        ]),
+      );
+      final result = engine.evaluate(
+        seq([frac]),
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, r'\frac{1}{2}\sqrt{2}');
+    });
+
+    test('整數結果 fraction 模式 formattedTex 為 null（純文字顯示）', () {
+      final root = seq([
+        NumberNode.create('2'),
+        OperatorNode.create(ExpressionOperator.add),
+        NumberNode.create('3'),
+      ]);
+      final result = engine.evaluate(
+        root,
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, isNull);
+      expect(result.formattedValue, '5');
+    });
+
+    test('sin(30°) fraction 模式 -> null（bail-out，退回小數）', () {
+      final root = seq([
+        FunctionNode(
+          id: NodeId.generate(),
+          function: MathFunction.sin,
+          argument: seq([NumberNode.create('30')]),
+        ),
+      ]);
+      final result = engine.evaluate(
+        root,
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, isNull);
+      // formattedValue 仍為小數 0.5。
+      expect(result.formattedValue, '0.5');
+    });
+
+    test('√2 + √3 fraction 模式 -> \\sqrt{2} + \\sqrt{3}', () {
+      final root = seq([
+        RootNode(
+          id: NodeId.generate(),
+          radicand: seq([NumberNode.create('2')]),
+        ),
+        OperatorNode.create(ExpressionOperator.add),
+        RootNode(
+          id: NodeId.generate(),
+          radicand: seq([NumberNode.create('3')]),
+        ),
+      ]);
+      final result = engine.evaluate(
+        root,
+        angleMode: AngleMode.degree,
+        resultFormat: ResultFormatPreference.fraction,
+      );
+      expect(result.formattedTex, r'\sqrt{2} + \sqrt{3}');
     });
   });
 }


### PR DESCRIPTION
This pull request introduces a robust, production-grade workflow for building **signed Android APKs** and implements an **exact fraction/surd display mode (FRAC)** toggle for calculation results. It ensures all Android release builds are properly signed, validated, and securely handle secrets, and adds a user-facing feature for toggling between decimal and exact (fraction/surd) result formats, with full persistence and UI integration. The changes touch the CI/CD pipeline, Android Gradle configuration, and the calculator's core logic, UI, and settings.

---

**Android Release Build Hardening & Signing**

- **CI/CD: Enforce signed release APKs with secure secrets handling and validation.**  
  The GitHub Actions workflow (`.github/workflows/build-release.yml`) now strictly requires all Android signing secrets to be present, restores the keystore and key properties at build time, verifies both the keystore and the final APK signature, and securely deletes signing files after use. Any missing or invalid secrets will fail the build, eliminating fallback to debug signing. [[1]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L77-R84) [[2]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R108-R257) [[3]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R267-R370) [[4]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R405-R414)

- **Gradle: Configure release signing and fail on missing/invalid keystore.**  
  The Android Gradle build (`android/app/build.gradle.kts`) now loads signing config from `key.properties`, throws explicit errors if required fields or files are missing, and only allows release builds when the keystore is present and valid. [[1]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbR1-R21) [[2]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL18-R95)

- **Other Android build improvements:**  
  - Application ID updated to `com.swarfte.scientific_calculator` for release.
  - Java version for GitHub Actions set to 17 (from 25) for compatibility.
  - Minor gradle properties update for warnings.

---

**Calculator Feature: Exact Fraction/Surd (FRAC) Display Mode**

- **New exact math engine for symbolic results:**  
  Introduces an exact algebra module (`lib/features/calculator/service/exact_math/`) with a `Rational` type, `ExactNumber` (sum of rational surds), AST evaluator, and formatter to produce simplified fractions, mixed numbers, and surds as TeX strings. Falls back to decimal when exact form isn't possible.

- **Result format preference (DEC/FRAC) with persistence and UI toggle:**  
  - Adds `ResultFormatPreference` and storage in `result_format_settings.dart`, loaded at app start and persisted via `SharedPreferences` (mirroring theme settings). [[1]](diffhunk://#diff-4a3c69ccbc3234d5726fe76bf201c918ebdb9c5561c25e3d82c482331e1956d1R1-R72) [[2]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3R8) [[3]](diffhunk://#diff-a0c8b26ba4b788aa1cb9eaf1da70ed023a1e4da3bd347484b3af356099aa00b3R67-R79)
  - New UI chip (`ResultFormatIndicator`) in the calculator AppBar lets users toggle between decimal and exact modes, updating results instantly.

- **Calculation pipeline and view-model updated:**  
  - Calculator engine and view-model now pass and respect the result format preference, evaluating and formatting results accordingly.
  - `CalculationResult` includes an optional TeX field for exact results; UI renders this using `flutter_math_fork` when available.

- **Comprehensive tests:**  
  - New and extended tests cover all new exact math logic, settings persistence, and UI integration.

---

These changes ensure all release APKs are securely and verifiably signed, and give users a powerful new way to view results as exact fractions or surds, enhancing both reliability and user experience.