### PR TITLE
Skip invisible cursor steps and fix TeX spacing

### DIFF
--- a/.zcode/plans/plan-sess_9c1a490d-ea89-4353-86b6-6e07fa81436f.md
+++ b/.zcode/plans/plan-sess_9c1a490d-ea89-4353-86b6-6e07fa81436f.md
@@ -1,0 +1,58 @@
+## 修復方案：合併視覺不可見的導航中間步（按一下 → 即可跳出函數括號）
+
+### 根本原因（已用測試證實）
+`ExpressionNavigator._moveRight` 在游標於「複合 node 的唯一子 sequence 末端 NumberNode 文字末端」時，會分兩步移動：
+
+`sin(30|)`（text mode, `30` 末端）按一下 `→`：
+- 規則 1（L91-101）：離開 NumberNode 至其後方間隙 → `argument` sequence 內 gap mode, `nodeOffset=1`。Serialize 結果 `\sin\left(30\vert\right)`。
+- 第 2 下才走規則 2（L104-106）`_leaveSequenceEnd` → 跳出 function → `\sin\left(30\right)\vert`。
+
+第 0、1 步的 visible TeX **完全相同**（`\sin\left(30\vert\right)`），所以第 1 下視覺無變化 → 需按 2 下。
+
+**影響範圍**：所有「owner 只有單一可編輯 child sequence」的 node —— `FunctionNode`(argument)、`GroupNode`(content)、`RootNode`(square root radicand)。`FractionNode` 有兩個 sequence，numerator 末端向右會到 denominator（gap 步有視覺意義），**不受影響**。
+
+對稱的向左問題也存在：`sin(|30)`（text mode, offset 0）向左目前也是兩下（先到 argument 開頭 gap，再離開 function），兩步視覺相同。
+
+### 修改 1：`lib/features/calculator/service/expression_navigator.dart`
+
+**A. `_moveRight` 規則 1（text 末端，L91-101）** —— 離開 NumberNode 至後方間隙後，若同時滿足：
+1. 該 NumberNode 是所在 sequence 的**最後**一個 child（`nodeOffset+1 == sequence.children.length`），且
+2. 該 sequence 是其 owner 的**最後一個**可編輯 child sequence（`_nextSiblingSequence` 回 null —— 即沒有下一個 sibling sequence 可去），
+
+則**直接再執行一次 `_leaveSequenceEnd`** 跳出 owner，把兩步合併成一步。
+
+**B. `_moveLeft` 規則 2（text 開頭 offset 0，L67-70）** —— 離開 NumberNode 至前方間隙後，若：
+1. 該 NumberNode 是 sequence 的**第一個** child（`nodeOffset == 0`），且
+2. 該 sequence 是其 owner 的**第一個**可編輯 child sequence（`_previousSiblingSequence` 回 null），
+
+則**直接執行 `_leaveSequenceStart`** 跳出 owner。
+
+兩處都重用既有 helpers（`_leaveSequenceEnd`/`_leaveSequenceStart`/`_nextSiblingSequence`/`_previousSiblingSequence`），它們內部對 root sequence 已有 null 安全處理。判斷需要 `findParentOfSequence` 取 location —— 已在 helpers 中使用，模式一致。
+
+Fraction 的分子/分母情況因「最後/第一個 sibling」條件不成立（還有對方可去）而**保持原行為**，不破壞既有 numerator→denominator 導航。
+
+### 修改 2：測試更新（兩個既有測試鎖死了 buggy 行為）
+
+- **`test/features/calculator/service/tree_expression_editor_test.dart` L495-510** (`輸入 sin 後向右離開 argument`)：把兩次 `moveRight` 改為**一次**即應到達 root，斷言 `sequenceId == root.id` 且 `nodeOffset == 1`。
+- **`test/features/calculator/viewmodel/calculator_view_model_test.dart` L58-70** (`從 function argument 向右離開`)：同樣兩次 `moveRight` 改為一次，更新註釋（移除「先離開 number 至 argument 末端，再…」描述）。
+
+### 新增測試（`test/features/calculator/service/expression_navigator_test.dart`）
+
+在 `FunctionNode navigation` group 新增回歸測試，鎖定新行為：
+1. `sin(30|)` text 末端按一下 `→` → 直接到 root（`sin(30)|`），不再停在 argument 內 gap。
+2. `sin(|30)` text 開頭按一下 `←` → 直接到 function 前方間隙。
+3. `GroupNode` content 末端 text 按一下 `→` → 離開 group（驗證單一 sequence 通用性）。
+4. `RootNode`（square root）radicand 末端 text 按一下 `→` → 離開 root。
+5. **保留行為測試**：`FractionNode` numerator 末端 text 按 `→` → 仍到 denominator（確認沒被誤改）。
+
+### 為什麼是這個方案
+- **改在 navigator（游標邏輯層）**，符合職責 —— serializer 與 evaluator 不需動。
+- 重用既有 helpers，最小侵入：只改 `_moveRight`/`_moveLeft` 各一條規則的尾端判斷。
+- 「最後/第一個 sibling sequence 不存在」這個條件精準區分了「該合併的步」（單 sequence owner）與「不該合併的步」（Fraction 多 sequence），不影響既有 fraction/root degree 導航。
+- 對稱修復向左方向，避免只修一邊造成的不一致。
+
+### 驗證
+1. `flutter test test/features/calculator/service/expression_navigator_test.dart` 全綠。
+2. `flutter test`（全套）全綠。
+3. `flutter analyze` 對修改檔案無 issue。
+4. （手動）輸入 `sin(30)` 後游標在 `30` 末端，按一下 `→` 即跳到 `sin(30)|`；`cos`/`tan`/`log`/`ln` 同樣；`sin(|30)` 向左一下即離開 function。

--- a/lib/features/calculator/service/expression_navigator.dart
+++ b/lib/features/calculator/service/expression_navigator.dart
@@ -66,6 +66,14 @@ class ExpressionNavigator {
 
     // 2. NumberNode 開頭（textOffset == 0）：離開至該 node 前方間隙。
     if (textOffset == 0) {
+      // 對稱於 _moveRight 規則 1 的合併：若此 NumberNode 是所在 sequence 的
+      // 第一個 child，且該 sequence 是其 owner 的第一個可編輯 child sequence，
+      // 則此間隙與 text 開頭視覺完全相同（隱形中間步），直接 _leaveSequenceStart
+      // 跳出 owner。
+      if (cursor.nodeOffset == 0 &&
+          _isFirstEditableSequence(index, cursor.sequenceId)) {
+        return _leaveSequenceStart(index, cursor.sequenceId);
+      }
       return cursor.copyWith(clearTextOffset: true);
     }
 
@@ -94,10 +102,20 @@ class ExpressionNavigator {
         return cursor.copyWith(textOffset: textOffset + 1);
       }
       // 末端：離開至 node 後方間隙。
-      return CursorPosition(
+      final gapAfterNumber = CursorPosition(
         sequenceId: cursor.sequenceId,
         nodeOffset: cursor.nodeOffset + 1,
       );
+      // 若此間隙位於 sequence 末端，且該 sequence 是其 owner 的最後一個可編輯
+      // child sequence（例如 function argument / group content / square root
+      // radicand），則此間隙與前一個 text 末端視覺完全相同（TeX 相同），
+      // 形成「按一下無變化」的隱形中間步。此時直接執行 _leaveSequenceEnd
+      // 把兩步合併，讓單次方向鍵即有可見效果。
+      if (gapAfterNumber.nodeOffset >= sequence.children.length &&
+          _isLastEditableSequence(index, cursor.sequenceId)) {
+        return _leaveSequenceEnd(index, cursor.sequenceId);
+      }
+      return gapAfterNumber;
     }
 
     // 2. 已在 sequence 結尾：離開 owner node 至 parent sequence 後方間隙。
@@ -313,6 +331,31 @@ class ExpressionNavigator {
       return null;
     }
     return siblings[currentIndex - 1].sequence;
+  }
+
+  /// 判斷 [sequenceId] 所指 sequence 是否為其 owner 的「最後一個」可編輯 child
+  /// sequence。root sequence（無 owner）回傳 true。
+  ///
+  /// 用於偵測視覺不可見的導航中間步：當游標位於 sequence 末端時，若沒有下一個
+  /// sibling sequence，下一步即離開 owner；此時間隙步與前一步視覺相同，應合併。
+  bool _isLastEditableSequence(TreeIndex index, NodeId sequenceId) {
+    final location = index.findParentOfSequence(sequenceId);
+    if (location == null) {
+      return true;
+    }
+    return _nextSiblingSequence(location) == null;
+  }
+
+  /// 判斷 [sequenceId] 所指 sequence 是否為其 owner 的「第一個」可編輯 child
+  /// sequence。root sequence（無 owner）回傳 true。
+  ///
+  /// `_isLastEditableSequence` 的對稱版本，用於向左方向的隱形中間步偵測。
+  bool _isFirstEditableSequence(TreeIndex index, NodeId sequenceId) {
+    final location = index.findParentOfSequence(sequenceId);
+    if (location == null) {
+      return true;
+    }
+    return _previousSiblingSequence(location) == null;
   }
 
   /// 回傳同一 owner 中，role 順序在 [location] 之後的可編輯 sequence。

--- a/lib/features/calculator/service/tree_expression_tex_serializer.dart
+++ b/lib/features/calculator/service/tree_expression_tex_serializer.dart
@@ -303,14 +303,18 @@ class TreeExpressionTexSerializer {
     return switch (operator) {
       ExpressionOperator.add => '+',
       ExpressionOperator.subtract => '-',
-      ExpressionOperator.multiply => r'\times',
-      ExpressionOperator.divide => r'\div',
+      // 末尾空格：分隔巨集名，避免與後方字母 token（如常數 e）黏成未定義
+      // 巨集（\timese）導致 Math renderer layout 失敗。空格為 LaTeX 標準巨集
+      // 終止符，視覺與無空格一致。
+      ExpressionOperator.multiply => r'\times ',
+      ExpressionOperator.divide => r'\div ',
     };
   }
 
   String _constantTex(MathConstant constant) {
     return switch (constant) {
-      MathConstant.pi => r'\pi',
+      // 同上：\pi 需以空格與後方字母 token 分隔。
+      MathConstant.pi => r'\pi ',
       MathConstant.e => 'e',
       MathConstant.answer => r'\operatorname{Ans}',
     };

--- a/test/features/calculator/service/expression_navigator_test.dart
+++ b/test/features/calculator/service/expression_navigator_test.dart
@@ -246,6 +246,183 @@ void main() {
     });
   });
 
+  // 單一 child-sequence owner（function / group / root）的「隱形中間步」回歸：
+  // 游標在末端 NumberNode 文字末端（或開頭）時，單次方向鍵應合併步驟、
+  // 直接離開 owner，避免「按一下視覺無變化、需按兩下」。
+  group('invisible-step skip（單一 sequence owner）', () {
+    test('sin(30|) 文字末端向右一下 -> 直接離開 function 至 root', () {
+      final argument = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('30')],
+      );
+      final function = FunctionNode(
+        id: NodeId.generate(),
+        function: MathFunction.sin,
+        argument: argument,
+      );
+      final root = SequenceNode(id: NodeId.generate(), children: [function]);
+      final doc = TreeExpressionDocument(
+        root: root,
+        cursor: CursorPosition(
+          sequenceId: argument.id,
+          nodeOffset: 0,
+          textOffset: 2, // 30|
+        ),
+      );
+
+      final moved = navigator.moveRight(doc);
+
+      expect(moved.cursor.sequenceId, root.id);
+      expect(moved.cursor.nodeOffset, 1); // function 後方間隙
+      expect(moved.cursor.textOffset, isNull);
+    });
+
+    test('sin(|30) 文字開頭向左一下 -> 直接離開 function 至前方間隙', () {
+      final argument = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('30')],
+      );
+      final function = FunctionNode(
+        id: NodeId.generate(),
+        function: MathFunction.sin,
+        argument: argument,
+      );
+      final root = SequenceNode(id: NodeId.generate(), children: [function]);
+      final doc = TreeExpressionDocument(
+        root: root,
+        cursor: CursorPosition(
+          sequenceId: argument.id,
+          nodeOffset: 0,
+          textOffset: 0, // |30
+        ),
+      );
+
+      final moved = navigator.moveLeft(doc);
+
+      expect(moved.cursor.sequenceId, root.id);
+      expect(moved.cursor.nodeOffset, 0); // function 前方間隙
+      expect(moved.cursor.textOffset, isNull);
+    });
+
+    test('group content 文字末端向右一下 -> 直接離開 group', () {
+      final content = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('5')],
+      );
+      final group = GroupNode(id: NodeId.generate(), content: content);
+      final root = SequenceNode(id: NodeId.generate(), children: [group]);
+      final doc = TreeExpressionDocument(
+        root: root,
+        cursor: CursorPosition(
+          sequenceId: content.id,
+          nodeOffset: 0,
+          textOffset: 1, // 5|
+        ),
+      );
+
+      final moved = navigator.moveRight(doc);
+
+      expect(moved.cursor.sequenceId, root.id);
+      expect(moved.cursor.nodeOffset, 1); // group 後方間隙
+    });
+
+    test('square root radicand 文字末端向右一下 -> 直接離開 root', () {
+      final radicand = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('2')],
+      );
+      final root = RootNode(
+        id: NodeId.generate(),
+        radicand: radicand,
+      );
+      final sequence = SequenceNode(
+        id: NodeId.generate(),
+        children: [root],
+      );
+      final doc = TreeExpressionDocument(
+        root: sequence,
+        cursor: CursorPosition(
+          sequenceId: radicand.id,
+          nodeOffset: 0,
+          textOffset: 1, // 2|
+        ),
+      );
+
+      final moved = navigator.moveRight(doc);
+
+      expect(moved.cursor.sequenceId, sequence.id);
+      expect(moved.cursor.nodeOffset, 1); // root 後方間隙
+    });
+  });
+
+  group('多 sequence owner 保留原行為（不誤合併）', () {
+    test('Fraction numerator 文字末端向右一下 -> 停在 numerator 末端間隙（不跳過 fraction）', () {
+      final numerator = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('1')],
+      );
+      final denominator = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('2')],
+      );
+      final fraction = FractionNode(
+        id: NodeId.generate(),
+        numerator: numerator,
+        denominator: denominator,
+      );
+      final root = SequenceNode(id: NodeId.generate(), children: [fraction]);
+      final doc = TreeExpressionDocument(
+        root: root,
+        cursor: CursorPosition(
+          sequenceId: numerator.id,
+          nodeOffset: 0,
+          textOffset: 1, // 1|
+        ),
+      );
+
+      final moved = navigator.moveRight(doc);
+
+      // 仍有 sibling sequence（denominator）可去，不符合合併條件：停在
+      // numerator 末端間隙（與 flat sequence 一致，下一步才到 denominator）。
+      expect(moved.cursor.sequenceId, numerator.id);
+      expect(moved.cursor.nodeOffset, 1);
+      expect(moved.cursor.textOffset, isNull);
+    });
+
+    test('Fraction denominator 文字開頭向左一下 -> 停在 denominator 開頭間隙（不跳過 fraction）', () {
+      final numerator = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('1')],
+      );
+      final denominator = SequenceNode(
+        id: NodeId.generate(),
+        children: [NumberNode.create('2')],
+      );
+      final fraction = FractionNode(
+        id: NodeId.generate(),
+        numerator: numerator,
+        denominator: denominator,
+      );
+      final root = SequenceNode(id: NodeId.generate(), children: [fraction]);
+      final doc = TreeExpressionDocument(
+        root: root,
+        cursor: CursorPosition(
+          sequenceId: denominator.id,
+          nodeOffset: 0,
+          textOffset: 0, // |2
+        ),
+      );
+
+      final moved = navigator.moveLeft(doc);
+
+      // 仍有 sibling sequence（numerator）可去，不符合合併條件：停在
+      // denominator 開頭間隙（與 flat sequence 一致，下一步才到 numerator）。
+      expect(moved.cursor.sequenceId, denominator.id);
+      expect(moved.cursor.nodeOffset, 0);
+      expect(moved.cursor.textOffset, isNull);
+    });
+  });
+
   group('FractionNode left/right navigation', () {
     late FractionNode fraction;
     late SequenceNode root;

--- a/test/features/calculator/service/tree_expression_editor_test.dart
+++ b/test/features/calculator/service/tree_expression_editor_test.dart
@@ -501,8 +501,8 @@ void main() {
       doc = editor.insertDigit(doc, '3');
       doc = editor.insertDigit(doc, '0');
 
-      // cursor 在 argument 末端，向右離開 function。
-      doc = navigator.moveRight(doc);
+      // cursor 在 NumberNode 30 文字末端；單次向右即合併隱形中間步、
+      // 直接離開 function 至 root。
       doc = navigator.moveRight(doc);
 
       expect(doc.cursor.sequenceId, doc.root.id);

--- a/test/features/calculator/service/tree_expression_tex_serializer_test.dart
+++ b/test/features/calculator/service/tree_expression_tex_serializer_test.dart
@@ -58,7 +58,52 @@ void main() {
         ),
       );
       final tex = visibleTex(doc);
-      expect(tex, contains(r'6\times3\div2'));
+      // 巨集後以空格分隔（見 _operatorTex 註釋）。
+      expect(tex, contains(r'6\times 3\div 2'));
+    });
+
+    test('operators 接常數 e 不黏成未定義巨集（回歸）', () {
+      for (final op in [
+        ExpressionOperator.multiply,
+        ExpressionOperator.divide,
+      ]) {
+        final doc = docOf(
+          SequenceNode(
+            id: NodeId.generate(),
+            children: [
+              NumberNode.create('13'),
+              OperatorNode.create(op),
+              ConstantNode.create(MathConstant.e),
+            ],
+          ),
+        );
+        final tex = hiddenTex(doc);
+        switch (op) {
+          case ExpressionOperator.multiply:
+            expect(tex, contains(r'13\times e'));
+            expect(tex, isNot(contains(r'\timese')));
+          case ExpressionOperator.divide:
+            expect(tex, contains(r'13\div e'));
+            expect(tex, isNot(contains(r'\dive')));
+          default:
+            fail('unexpected operator $op');
+        }
+      }
+    });
+
+    test('pi 接常數 e 不黏成未定義巨集（回歸）', () {
+      final doc = docOf(
+        SequenceNode(
+          id: NodeId.generate(),
+          children: [
+            ConstantNode.create(MathConstant.pi),
+            ConstantNode.create(MathConstant.e),
+          ],
+        ),
+      );
+      final tex = hiddenTex(doc);
+      expect(tex, contains(r'\pi e'));
+      expect(tex, isNot(contains(r'\pie')));
     });
 
     test('constants pi / e / Ans', () {
@@ -73,8 +118,8 @@ void main() {
         ),
       );
       final tex = hiddenTex(doc);
-      expect(tex, contains(r'\pi'));
-      expect(tex, contains('e'));
+      // \pi 與 e 必須為相異 token（不黏成 \pie）。
+      expect(tex, contains(r'\pi e'));
       expect(tex, contains(r'\operatorname{Ans}'));
     });
   });

--- a/test/features/calculator/viewmodel/calculator_view_model_test.dart
+++ b/test/features/calculator/viewmodel/calculator_view_model_test.dart
@@ -60,9 +60,8 @@ void main() {
       viewModel().inputDigit('3');
       viewModel().inputDigit('0');
 
-      // cursor 在 NumberNode 30 的文字末端；先離開 number 至 argument
-      // 末端，再向右離開 function 至 root。
-      viewModel().moveRight();
+      // cursor 在 NumberNode 30 的文字末端；單次向右即合併隱形中間步、
+      // 直接離開 function 至 root。
       viewModel().moveRight();
 
       expect(state().document.cursor.sequenceId, state().document.root.id);


### PR DESCRIPTION
Improve cursor navigation so a single left/right press exits function/group/root wrappers when the intermediate gap would be visually identical, while keeping fraction multi-sequence behavior unchanged. Also add LaTeX macro separators (`\times `, `\div `, `\pi `) to prevent merged undefined commands like `\timese`/`\pie`, with regression tests and updated expectations across navigator, editor, serializer, and view-model tests.