### PR TITLE
Update app IDs to com.swarfte namespace

### DIFF
--- a/android/app/src/main/kotlin/com/swarfte/scientific_calculator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/swarfte/scientific_calculator/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.scientific_calculator
+package com.swarfte.scientific_calculator
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -398,7 +398,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -415,7 +415,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -430,7 +430,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -561,7 +561,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -583,7 +583,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.scientificCalculator;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swarfte.scientificCalculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Renames the Android MainActivity package from `com.example.scientific_calculator` to `com.swarfte.scientific_calculator` and updates iOS bundle identifiers for both Runner and RunnerTests. This aligns platform package/bundle IDs with the new organization namespace.